### PR TITLE
fix(react-button): align package version with published npm release

### DIFF
--- a/.nx/version-plans/version-plan-1773009592241.md
+++ b/.nx/version-plans/version-plan-1773009592241.md
@@ -1,5 +1,0 @@
----
-react-button: patch
----
-
-Initial release of button component

--- a/libs/react/button/package.json
+++ b/libs/react/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@isolate-ui/button",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {


### PR DESCRIPTION
- Bump libs/react/button/package.json from 0.0.1 to 0.0.2 to match the version already published to npm on 2026-03-09
- Remove stale version plan that was causing repeated failed publishes (0.0.2 already published; plan was never consumed)

The correct git tag react-button@0.0.2 has been pushed and the mismatched button@0.0.2 tag removed, so currentVersionResolver: git-tag will now resolve correctly on future releases.

Closes #40