### PR TITLE
ci: add check-version-plan job to enforce version plans in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
               # here (rather than grep -c across the whole file) means body-level
               # horizontal rules (also '---') are never counted as delimiters.
               # awk's exit code is preserved by separating it from tr -d.
-              plan_projects_raw=$(awk '
+              if ! plan_projects_raw=$(awk '
                 NR == 1 && /^---$/ { delimiters = 1; next }
                 NR == 1 {
                   print "ERROR: version plan does not begin with --- frontmatter" > "/dev/stderr"
@@ -133,8 +133,7 @@ jobs:
                     exit 1
                   }
                 }
-              ' "$plan")
-              if [ $? -ne 0 ]; then
+              ' "$plan"); then
                 echo "ERROR: version plan '$plan' has malformed frontmatter."
                 exit 1
               fi


### PR DESCRIPTION
## Summary

Fixes #44 — adds a `check-version-plan` CI job that fails a PR if any affected releasable project (`libs/**`) is missing a `.nx/version-plans/*.md` entry.

## Problem

`nx release` with `"versionPlans": true` silently exits with code `0` when no version plan file exists, causing the release workflow to report success while producing no release, no version bump, and no changelog entry.

## Solution

A new CI job runs on every PR to `main` and:

1. Identifies affected projects under `libs/` using `nx show projects --affected`.
2. Parses the YAML frontmatter of every `.nx/version-plans/*.md` file to collect covered project names.
3. Fails with a clear error message if any affected releasable project is not covered, directing contributors to run `nx release plan <bump> --projects <name>`.
4. Passes (exits `0`) if no releasable projects are affected (e.g. CI-only or docs PRs).

## Example failure output

```
ERROR: The following affected releasable projects have no version plan:
  - react-button

Run the following command and commit the generated file:
  pnpm nx release plan <major|minor|patch> --projects react-button

See: https://nx.dev/recipes/nx-release/file-based-versioning-version-plans
```
