### PR TITLE
fix(utils): fix TypeScript errors in a11y helper to unblock releases

### DIFF
--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -20,7 +20,8 @@
   },
   "peerDependencies": {
     "@axe-core/playwright": "^4.0.0",
-    "@playwright/test": "^1.0.0"
+    "@playwright/test": "^1.0.0",
+    "axe-core": "^4.0.0"
   },
   "devDependencies": {
     "vitest": "^3.2.4",

--- a/libs/utils/src/lib/a11y.ts
+++ b/libs/utils/src/lib/a11y.ts
@@ -1,5 +1,6 @@
 import { AxeBuilder } from '@axe-core/playwright';
 import type { Page, Locator } from '@playwright/test';
+import type { UnlabelledFrameSelector } from 'axe-core';
 
 /**
  * Accessibility violation details with formatted output
@@ -10,7 +11,7 @@ export interface A11yViolation {
   message: string;
   nodes: Array<{
     html: string;
-    target: string[];
+    target: UnlabelledFrameSelector;
   }>;
 }
 
@@ -53,7 +54,7 @@ export async function scanForA11yViolations(
   builder.withTags(['wcag2aa', 'wcag21aa']);
 
   if (options?.runOnly) {
-    builder.withRunOnly(options.runOnly);
+    builder.options({ runOnly: options.runOnly });
   }
 
   if (options?.rules) {
@@ -123,7 +124,7 @@ export async function expectToHaveNoA11yViolations(
         const nodeDetails = v.nodes
           .map(
             (n) =>
-              `\n    - Selector: ${n.target.join(' > ')}\n      HTML: ${n.html}`,
+              `\n    - Selector: ${n.target.map((t) => (Array.isArray(t) ? t.join(' ') : t)).join(' > ')}\n      HTML: ${n.html}`,
           )
           .join('\n');
         return `\n  [${v.impact?.toUpperCase() || 'UNKNOWN'}] ${v.id}\n    Message: ${v.message}${nodeDetails}`;


### PR DESCRIPTION
## Summary

Fixes three TypeScript compilation errors in `libs/utils/src/lib/a11y.ts` that were blocking the release pipeline.

Closes #52

---

## Changes

### 1. Fix invalid `AxeBuilder` API call
`AxeBuilder` from `@axe-core/playwright@4.11.1` has no `withRunOnly()` method. Replaced with the correct `.options({ runOnly: ... })` API.

### 2. Fix `A11yViolation` type definition
Imported `UnlabelledFrameSelector` from `axe-core` and used it for `A11yViolation.nodes[].target`, which matches the actual `NodeResult.target` type. The previous `string[]` was too narrow and caused a type error when assigning values from axe-core results (needed to support shadow DOM nested array selectors).

### 3. Fix error message formatter for shadow DOM selectors
Updated the violation report formatter to handle elements where `target` entries may be nested arrays (shadow DOM), preventing a runtime crash when formatting violation output.

---

## Validation

- `pnpm tsc --project libs/utils/tsconfig.lib.json --noEmit` — passes with no errors
- `pnpm vitest run --project utils` — 1 test file, 1 test, all pass
