### PR TITLE
docs: add triage policy, copilot instructions and pre-PR reviewer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,4 @@ See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy
 
 <!-- Link any follow-up issues for Major or Minor items deferred from this PR. -->
 <!-- Format: "- #N — brief description" -->
-<!-- Remove this section if there are no deferred items. -->
+<!-- If there are no deferred items, write "None" below. Do NOT remove this section — CI requires it to be present. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Copilot Review Triage
 
-Before requesting review, confirm each tier has been addressed:
+Before opening the PR, confirm each tier has been addressed:
 
 - [ ] **Blocker** — All security and correctness issues fixed
 - [ ] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Changes
+
+<!-- List the key changes made. -->
+
+## Copilot Review Triage
+
+Before requesting review, confirm each tier has been addressed:
+
+- [ ] **Blocker** — All security and correctness issues fixed
+- [ ] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
+- [ ] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
+- [ ] **Nit** — Review threads resolved with a written rationale (no code change required)
+
+See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.
+
+## Deferred follow-ups
+
+<!-- Link any follow-up issues for Major or Minor items deferred from this PR. -->
+<!-- Format: "- #N — brief description" -->
+<!-- Remove this section if there are no deferred items. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,4 +121,4 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 
 - **Run the pre-PR reviewer automatically at the end of every phase of work.** Do not wait for a human to ask. In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings before reporting phase completion or starting the next phase. Do not open the PR until Blocker and Major findings are resolved.
 - **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
-- **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. Leaving boxes unchecked causes CI to fail — this is intentional: it means the review was not completed.
+- **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. CI requires all four triage checkboxes to be checked (`[x]`) and will fail if fewer than four are present — this is intentional: it means the review was not completed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,6 +119,6 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 
 ## PR Workflow
 
-- **Run the pre-PR reviewer before opening or updating a PR.** In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings. Do not open the PR until Blocker and Major findings are resolved.
+- **Run the pre-PR reviewer automatically at the end of every phase of work.** Do not wait for a human to ask. In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings before reporting phase completion or starting the next phase. Do not open the PR until Blocker and Major findings are resolved.
 - **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
 - **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. Leaving boxes unchecked causes CI to fail — this is intentional: it means the review was not completed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,3 +114,11 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 
 - All imports between Nx projects must use the workspace aliases defined in `tsconfig.base.json` (e.g. `@isolate-ui/utils`, `@isolate-ui/tokens`). Never use relative paths that cross project boundaries.
 - Generated or build-output directories (`styled-system/`, `dist/`, `playwright/.cache/`) must never be committed or imported from source.
+
+---
+
+## PR Workflow
+
+- **Run the pre-PR reviewer before opening or updating a PR.** In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings. Do not open the PR until Blocker and Major findings are resolved.
+- **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
+- **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. Leaving boxes unchecked causes CI to fail — this is intentional: it means the review was not completed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,116 @@
+# Isolate UI — Copilot Coding Instructions
+
+These rules apply to all code generated or edited by Copilot in this repository.
+Follow them precisely; do not silently deviate.
+
+---
+
+## Async / Error Handling
+
+- **No fire-and-forget.** Every top-level async call site must either `await` the call inside a `try/catch`, or chain `.catch()` with a handler that logs and exits (or re-throws). This applies to: command handlers (`approve.ts`, `fix.ts`, `query.ts`), startup functions, and any background work initiated from a route handler.
+- Mid-level `async` functions that are themselves `await`-ed do not need their own `.catch()` — rejection propagates to the caller.
+- Fastify route handlers must either `throw` on error or call `reply.status(N).send(err)`. Never swallow an error silently.
+
+```typescript
+// ✅ correct — top-level entry point
+start().catch((err) => {
+  console.error('[service] fatal startup error:', err);
+  process.exit(1);
+});
+
+// ❌ wrong — unhandled rejection if start() throws
+start();
+```
+
+---
+
+## Security
+
+- **Webhook HMAC verification must happen before any payload parsing or business logic.** Never read `request.body` fields before the signature is confirmed valid.
+- **Authorization checks must precede business logic.** Verify the actor's role/permission before touching state, the database, or external services.
+- **No secrets or tokens in log output.** Use a redaction helper or log only the first/last N characters. Never log `GITHUB_TOKEN`, `WEBHOOK_SECRET`, or equivalent.
+- Environment variables required for the service to function must be validated at startup with an explicit `process.exit(1)` and a clear error message if absent.
+
+```typescript
+// ✅ correct order
+verifyHmac(request); // 1. verify signature
+checkAuthorization(actor); // 2. check permission
+await processCommand(payload); // 3. business logic
+
+// ❌ wrong order — processes payload before verifying identity
+await processCommand(payload);
+verifyHmac(request);
+```
+
+---
+
+## TypeScript
+
+- **No `any` at public API boundaries** (exported function parameters, return types, Zod schemas, HTTP route types). Use `unknown` with explicit type narrowing instead.
+- **New I/O boundaries must use Zod.** Any new HTTP route handler, database read, or environment variable block introduced after May 2026 must parse its input with a Zod schema. Existing `IssueCommentPayload`-style interfaces do not need to be retrofitted.
+- Use `as const` for literal enum-like values shared across modules.
+- Prefer explicit return types on exported functions.
+
+```typescript
+// ✅ new route — Zod schema
+const BodySchema = z.object({ command: z.string(), issueId: z.number() });
+const body = BodySchema.parse(request.body);
+
+// ❌ no validation — unknown shape at runtime
+const body = request.body as MyInterface;
+```
+
+---
+
+## Testing
+
+- Every new **exported function** must have at least one test covering the failure / error path, not only the happy path.
+- Every new **async function** must have at least one test that verifies what happens when the async operation rejects or throws.
+- Mock external dependencies (`Octokit`, SQLite DB, LLM clients) — never make real network calls in unit tests.
+- Test files live alongside source files or in `__tests__/` directories within the same project. Do not place tests outside the project boundary.
+
+```typescript
+// ✅ error path tested
+it('throws when GITHUB_TOKEN is missing', () => {
+  delete process.env.GITHUB_TOKEN;
+  expect(() => validateEnv()).toThrow('GITHUB_TOKEN');
+});
+```
+
+---
+
+## LangGraph / AI Orchestrator
+
+- **State mutations must be via the return object only.** Never mutate `state` directly inside a node function. Return a `Partial<AgentState>` with only the fields that changed.
+- Channel reducers handle merging — returning the full state causes duplicate data.
+
+```typescript
+// ✅ correct — return only what changed
+return { next_recipient: 'dev', signoffs: { po: true } };
+
+// ❌ wrong — direct mutation
+state.next_recipient = 'dev';
+return state;
+```
+
+---
+
+## SQLite
+
+- **Parameterized queries only.** Never interpolate user-supplied or externally-sourced values into a SQL string.
+- Use `INSERT OR IGNORE` for idempotent inserts (e.g., deduplication tables).
+
+```typescript
+// ✅ correct
+db.prepare('SELECT * FROM deliveries WHERE id = ?').get(deliveryId);
+
+// ❌ wrong — SQL injection risk
+db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
+```
+
+---
+
+## Project Structure
+
+- All imports between Nx projects must use the workspace aliases defined in `tsconfig.base.json` (e.g. `@isolate-ui/utils`, `@isolate-ui/tokens`). Never use relative paths that cross project boundaries.
+- Generated or build-output directories (`styled-system/`, `dist/`, `playwright/.cache/`) must never be committed or imported from source.

--- a/.github/prompts/pre-pr-review.prompt.md
+++ b/.github/prompts/pre-pr-review.prompt.md
@@ -1,0 +1,92 @@
+---
+mode: ask
+description: >
+  Pre-PR reviewer: inspects current changes against the project's coding standards
+  and outputs a severity-classified findings table. Run at the end of each phase
+  of work before opening or updating a pull request.
+---
+
+You are a thorough code reviewer for the Isolate UI monorepo. Review the current
+uncommitted changes (or the diff since the base branch if changes are already staged/committed)
+against the project's coding standards defined in `.github/copilot-instructions.md`.
+
+## Review checklist
+
+For **every file changed**, check each of the following categories. Only report findings
+that actually apply — do not manufacture findings.
+
+### 1. Async / Error Handling
+
+- Top-level async call sites (command handlers, startup functions, background work
+  initiated from route handlers) must use `.catch()` or `try/catch`. Flag any
+  fire-and-forget call where the returned promise is not handled.
+- Fastify route handlers must either `throw` or call `reply.status(N).send(err)`.
+  Flag any route that silently swallows an error.
+
+### 2. Security
+
+- HMAC / signature verification must occur before any payload field is read or
+  business logic runs. Flag any route that processes the body before verifying the signature.
+- Authorization checks (role / permission verification) must precede business logic.
+  Flag any handler that touches state or calls external services before checking the actor's permission.
+- Secrets, tokens, or sensitive env var values must not appear in log statements.
+  Flag any `console.log`, `logger.info`, etc. that could leak a credential.
+
+### 3. TypeScript
+
+- No `any` at public API boundaries (exported function signatures, Zod schemas, HTTP
+  route types). Flag uses of `any`; suggest `unknown` with type narrowing instead.
+- Any **new** HTTP route handler, database read, or env-var block must parse its input
+  with a Zod schema. Flag missing Zod validation on new I/O boundaries only — do not
+  flag existing `IssueCommentPayload`-style interfaces.
+
+### 4. Testing
+
+- Every new **exported function** must have at least one test covering the error / failure path.
+- Every new **async function** must have at least one test that verifies what happens when
+  the operation rejects or throws.
+- Flag any new exported or async function with no corresponding test file changes.
+
+### 5. LangGraph
+
+- LangGraph node functions must return a `Partial<AgentState>` with only changed fields.
+  Flag any direct mutation of the `state` argument inside a node function.
+
+### 6. SQLite
+
+- All SQL queries must use parameterized statements. Flag any string interpolation or
+  template-literal SQL that incorporates runtime values.
+
+### 7. Project structure
+
+- Cross-project imports must use `@isolate-ui/*` workspace aliases from `tsconfig.base.json`.
+  Flag any relative `../` path that crosses an Nx project boundary.
+
+---
+
+## Output format
+
+Produce a **Findings Table** followed by a **Summary**.
+
+### Findings Table
+
+| #   | File | Line(s) | Severity | Category | Description | Suggested fix |
+| --- | ---- | ------- | -------- | -------- | ----------- | ------------- |
+
+Severity levels (use exactly these labels):
+
+- **Blocker** — Security defect or correctness issue that must be fixed before merging
+- **Major** — Reliability or correctness issue; fix in this PR if low-effort, otherwise track as a follow-up issue
+- **Minor** — Coverage or completeness gap; open a follow-up issue
+- **Nit** — Style or naming; resolve with a written rationale, no code change required
+
+If there are **no findings** in a category, omit that category from the table entirely.
+If there are **no findings at all**, output: `✅ No findings — all checks passed.`
+
+### Summary
+
+After the table, output a one-paragraph plain-English summary:
+
+- How many findings per severity tier
+- Which areas are clean
+- Whether the changes are ready to proceed to the next phase or need fixes first

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
     name: Check PR Template
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Validate PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -77,20 +82,23 @@ jobs:
             process.exit(1);
           }
 
-          // All four triage checkboxes must be checked [x].
-          // Requiring exactly 4 checked boxes is robust against list-marker
-          // variations (- vs * vs +) and prevents bypassing by deleting lines.
+          // Each of the four required triage tiers must be explicitly checked [x].
+          // Matching per-tier name (Blocker/Major/Minor/Nit) prevents bypassing by
+          // adding arbitrary [x] tokens or deleting/renaming checkbox lines.
           const triageStart = body.indexOf('## Copilot Review Triage');
           const triageEnd = body.indexOf('## Deferred follow-ups');
           const triageSection = triageStart !== -1 && triageEnd !== -1
             ? body.slice(triageStart, triageEnd)
             : '';
 
-          const checkedBoxes = (triageSection.match(/\[x\]/gi) ?? []).length;
-          if (checkedBoxes < 4) {
-            console.error(
-              `PR triage section has ${checkedBoxes} checked box(es) — all 4 are required.`
-            );
+          const requiredTiers = ['Blocker', 'Major', 'Minor', 'Nit'];
+          const uncheckedTiers = requiredTiers.filter(
+            (tier) => !new RegExp(`\\[x\\][^\\n]*\\b${tier}\\b`, 'i').test(triageSection)
+          );
+
+          if (uncheckedTiers.length > 0) {
+            console.error('The following triage items are missing or unchecked in the PR:');
+            uncheckedTiers.forEach((t) => console.error('  ' + t));
             console.error(
               'Run #pre-pr-review in VS Code Copilot Chat and tick every triage checkbox before opening the PR.'
             );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,58 @@ jobs:
       - name: Typecheck affected
         run: pnpm nx affected -t typecheck --base=origin/main
 
+  check-pr-template:
+    name: Check PR Template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node - <<'EOF'
+          const body = process.env.PR_BODY ?? '';
+
+          const requiredSections = [
+            '## Summary',
+            '## Changes',
+            '## Copilot Review Triage',
+            '## Deferred follow-ups',
+          ];
+
+          const missingSections = requiredSections.filter(
+            (s) => !body.includes(s)
+          );
+
+          if (missingSections.length > 0) {
+            console.error('PR body is missing required sections:');
+            missingSections.forEach((s) => console.error('  ' + s));
+            console.error(
+              'Use the PR template (.github/PULL_REQUEST_TEMPLATE.md) when opening a PR.'
+            );
+            process.exit(1);
+          }
+
+          // Unchecked boxes inside the triage section means the review
+          // was not completed before opening the PR.
+          const triageStart = body.indexOf('## Copilot Review Triage');
+          const triageEnd = body.indexOf('## Deferred follow-ups');
+          const triageSection = triageStart !== -1 && triageEnd !== -1
+            ? body.slice(triageStart, triageEnd)
+            : '';
+
+          if (/^- \[ \]/m.test(triageSection)) {
+            console.error(
+              'PR has unchecked triage boxes in the Copilot Review Triage section.'
+            );
+            console.error(
+              'Run #pre-pr-review in VS Code Copilot Chat and resolve all findings before opening the PR.'
+            );
+            process.exit(1);
+          }
+
+          console.log('PR template check passed.');
+          EOF
+
   check-version-plan:
     name: Check Version Plan
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,20 +77,22 @@ jobs:
             process.exit(1);
           }
 
-          // Unchecked boxes inside the triage section means the review
-          // was not completed before opening the PR.
+          // All four triage checkboxes must be checked [x].
+          // Requiring exactly 4 checked boxes is robust against list-marker
+          // variations (- vs * vs +) and prevents bypassing by deleting lines.
           const triageStart = body.indexOf('## Copilot Review Triage');
           const triageEnd = body.indexOf('## Deferred follow-ups');
           const triageSection = triageStart !== -1 && triageEnd !== -1
             ? body.slice(triageStart, triageEnd)
             : '';
 
-          if (/^- \[ \]/m.test(triageSection)) {
+          const checkedBoxes = (triageSection.match(/\[x\]/gi) ?? []).length;
+          if (checkedBoxes < 4) {
             console.error(
-              'PR has unchecked triage boxes in the Copilot Review Triage section.'
+              `PR triage section has ${checkedBoxes} checked box(es) — all 4 are required.`
             );
             console.error(
-              'Run #pre-pr-review in VS Code Copilot Chat and resolve all findings before opening the PR.'
+              'Run #pre-pr-review in VS Code Copilot Chat and tick every triage checkbox before opening the PR.'
             );
             process.exit(1);
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,11 +254,10 @@ nx affected -t test lint typecheck build
 
 ### Pre-PR Review (mandatory, phase-gated)
 
-Run the local pre-PR reviewer **at the end of every phase of work** — not only before opening a PR. Open the VS Code Copilot Chat panel and run:
+The pre-PR reviewer **must run at the end of every phase of work** — not only before opening a PR. This is not optional and must not wait for a human to remember to trigger it.
 
-```
-#pre-pr-review
-```
+- **AI agents**: run `#pre-pr-review` automatically as part of phase completion, before reporting back or starting the next phase.
+- **Humans**: open the VS Code Copilot Chat panel and run `#pre-pr-review`.
 
 **Before starting the next phase:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,21 @@ nx run-many -t typecheck
 nx run-many -t lint
 ```
 
+### Starting an Issue
+
+At the start of every issue, create a new branch from `main`:
+
+```bash
+# Ensure main is up to date
+git checkout main && git pull
+
+# Create a branch named after the issue number and a short slug
+git checkout -b <issue-number>-<short-description>
+# e.g. git checkout -b 65-copilot-review-loop
+```
+
+All work for the issue happens on this branch. Open the PR against `main` when the final phase is complete and the pre-PR reviewer has been run.
+
 ### Daily Development
 
 ```bash
@@ -236,6 +251,48 @@ nx build react-button
 # Run all tasks for affected projects
 nx affected -t test lint typecheck build
 ```
+
+### Pre-PR Review (mandatory, phase-gated)
+
+Run the local pre-PR reviewer **at the end of every phase of work** — not only before opening a PR. Open the VS Code Copilot Chat panel and run:
+
+```
+#pre-pr-review
+```
+
+**Before starting the next phase:**
+
+- Fix all **Blocker** and **Major** findings.
+- For **Minor** findings: either fix inline or open a follow-up GitHub issue.
+- For **Nit** findings: resolve with a written rationale — no code change required.
+- Nothing opens a PR until the reviewer has been run on the final phase output.
+
+See [`.github/prompts/pre-pr-review.prompt.md`](.github/prompts/pre-pr-review.prompt.md) for the prompt definition.
+
+## PR Review Triage Policy
+
+This policy applies to all Copilot (and human) review comments. Its purpose is to prevent endless review cycles by giving every comment a clear, bounded resolution path.
+
+### Severity Tiers
+
+| Tier                                  | Examples                                                                                             | Resolution                                                                                                                                                |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Blocker** (Security / Correctness)  | HMAC bypass, unhandled promise rejection, auth check after business logic, secrets in logs           | Fix before merge — no exceptions.                                                                                                                         |
+| **Major** (Correctness / Reliability) | Missing error handler, incorrect async pattern, broken edge case, type unsafety at a public boundary | Fix in the same PR if low-effort. If out of scope, open a follow-up issue and link it in the PR description before merging.                               |
+| **Minor** (Coverage / Completeness)   | Missing test for an error path, uncovered edge case, missing Zod schema on a new I/O boundary        | Open a follow-up issue. Resolve the review thread with `tracked as #N`.                                                                                   |
+| **Nit** (Style / Naming)              | Variable naming, comment wording, minor formatting deviation                                         | Resolve the thread with a one-sentence written rationale (e.g. "intentional: consistent with existing pattern in `webhook.ts`"). No code change required. |
+
+### Resolution without a code change
+
+For Minor and Nit items: post a reply on the review thread explaining the decision, then resolve the thread. A commit is **not** required. This prevents the commit → re-review spiral.
+
+### Deferred follow-ups
+
+Any Major or Minor item deferred to a follow-up issue **must** be linked in the PR description before the PR is merged. Use the "Deferred follow-ups" section of the PR template.
+
+### No hard round limit
+
+There is no fixed maximum number of review cycles. Use the triage table to bound each comment individually. If a review cycle is generating many Blocker/Major findings, that signals a quality gap — run the pre-PR reviewer earlier in the next phase of work.
 
 ## Commit Message Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,21 @@ Run the local pre-PR reviewer **at the end of every phase of work** — not only
 
 See [`.github/prompts/pre-pr-review.prompt.md`](.github/prompts/pre-pr-review.prompt.md) for the prompt definition.
 
+### Opening a PR (mandatory)
+
+Every PR **must** use the PR template at [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). GitHub inserts it automatically when creating a PR via the web UI or `gh pr create`. **Do not delete or skip sections** — CI runs a `check-pr-template` job that fails the build if:
+
+- Any of the four required sections (`## Summary`, `## Changes`, `## Copilot Review Triage`, `## Deferred follow-ups`) is missing, or
+- Any triage checkbox is left unchecked (`- [ ]`).
+
+**Workflow before opening the PR:**
+
+1. Run `#pre-pr-review` in VS Code Copilot Chat.
+2. Resolve all findings (fix Blockers/Majors; track Minors as issues; rationale for Nits).
+3. Open the PR — GitHub fills in the template automatically.
+4. Tick triage checkboxes only for the tiers you have verified are clean.
+5. Link any deferred follow-up issues in the `## Deferred follow-ups` section.
+
 ## PR Review Triage Policy
 
 This policy applies to all Copilot (and human) review comments. Its purpose is to prevent endless review cycles by giving every comment a clear, bounded resolution path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,7 @@ See [`.github/prompts/pre-pr-review.prompt.md`](.github/prompts/pre-pr-review.pr
 Every PR **must** use the PR template at [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). GitHub inserts it automatically when creating a PR via the web UI or `gh pr create`. **Do not delete or skip sections** — CI runs a `check-pr-template` job that fails the build if:
 
 - Any of the four required sections (`## Summary`, `## Changes`, `## Copilot Review Triage`, `## Deferred follow-ups`) is missing, or
-- Any triage checkbox is left unchecked (`- [ ]`).
+- Any of the four triage tiers (Blocker, Major, Minor, Nit) is missing or unchecked (`[x]`) in the Copilot Review Triage section.
 
 **Workflow before opening the PR:**
 


### PR DESCRIPTION
## Summary

Resolves the endless Copilot review loop by introducing three interlocking mechanisms: a documented triage policy, project-specific coding standards fed directly to Copilot, and a local pre-PR reviewer agent that catches issues before a PR is opened. Also adds CI enforcement so the process cannot be skipped silently.

## Changes

- `AGENTS.md` — Added Starting an Issue, Pre-PR Review (mandatory, phase-gated), and Opening a PR (mandatory) to the Development Workflow; added PR Review Triage Policy with Blocker/Major/Minor/Nit severity table
- `.github/PULL_REQUEST_TEMPLATE.md` — New PR template with triage checklist and deferred follow-ups section
- `.github/copilot-instructions.md` — New file encoding project coding standards; read automatically by Copilot for every session in this repo
- `.github/prompts/pre-pr-review.prompt.md` — New VS Code Copilot Chat prompt (#pre-pr-review) for pre-PR review
- `.github/workflows/ci.yml` — New check-pr-template CI job that fails if required sections are missing or triage checkboxes are unchecked

## Copilot Review Triage

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

## Deferred follow-ups

None — documentation and CI only; no source code changes.

Closes #65