### PR TITLE
feat(ai-orchestrator): add component boilerplate dev node (issue #22)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,4 @@ See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy
 
 <!-- Link any follow-up issues for Major or Minor items deferred from this PR. -->
 <!-- Format: "- #N — brief description" -->
-<!-- Remove this section if there are no deferred items. -->
+<!-- If there are no deferred items, write "None" below. Do NOT remove this section — CI requires it to be present. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Copilot Review Triage
 
-Before requesting review, confirm each tier has been addressed:
+Before opening the PR, confirm each tier has been addressed:
 
 - [ ] **Blocker** — All security and correctness issues fixed
 - [ ] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Changes
+
+<!-- List the key changes made. -->
+
+## Copilot Review Triage
+
+Before requesting review, confirm each tier has been addressed:
+
+- [ ] **Blocker** — All security and correctness issues fixed
+- [ ] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
+- [ ] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
+- [ ] **Nit** — Review threads resolved with a written rationale (no code change required)
+
+See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.
+
+## Deferred follow-ups
+
+<!-- Link any follow-up issues for Major or Minor items deferred from this PR. -->
+<!-- Format: "- #N — brief description" -->
+<!-- Remove this section if there are no deferred items. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,5 +120,7 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 ## PR Workflow
 
 - **Run the pre-PR reviewer automatically at the end of every phase of work.** Do not wait for a human to ask. In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings before reporting phase completion or starting the next phase. Do not open the PR until Blocker and Major findings are resolved.
+- **Wait for explicit human sign-off before committing.** After presenting the pre-PR review findings, do not commit or proceed to the next phase until the human has reviewed and approved. Never auto-commit immediately after the review.
+- **Phase changes must be committed before the next phase begins.** Once the human has signed off, commit the phase changes (one commit per phase) before starting any implementation work for the subsequent phase.
 - **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
 - **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. CI requires all four triage checkboxes to be checked (`[x]`) and will fail if fewer than four are present — this is intentional: it means the review was not completed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,4 +121,4 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 
 - **Run the pre-PR reviewer automatically at the end of every phase of work.** Do not wait for a human to ask. In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings before reporting phase completion or starting the next phase. Do not open the PR until Blocker and Major findings are resolved.
 - **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
-- **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. Leaving boxes unchecked causes CI to fail — this is intentional: it means the review was not completed.
+- **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. CI requires all four triage checkboxes to be checked (`[x]`) and will fail if fewer than four are present — this is intentional: it means the review was not completed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,6 +119,6 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 
 ## PR Workflow
 
-- **Run the pre-PR reviewer before opening or updating a PR.** In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings. Do not open the PR until Blocker and Major findings are resolved.
+- **Run the pre-PR reviewer automatically at the end of every phase of work.** Do not wait for a human to ask. In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings before reporting phase completion or starting the next phase. Do not open the PR until Blocker and Major findings are resolved.
 - **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
 - **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. Leaving boxes unchecked causes CI to fail — this is intentional: it means the review was not completed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,3 +114,11 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 
 - All imports between Nx projects must use the workspace aliases defined in `tsconfig.base.json` (e.g. `@isolate-ui/utils`, `@isolate-ui/tokens`). Never use relative paths that cross project boundaries.
 - Generated or build-output directories (`styled-system/`, `dist/`, `playwright/.cache/`) must never be committed or imported from source.
+
+---
+
+## PR Workflow
+
+- **Run the pre-PR reviewer before opening or updating a PR.** In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings. Do not open the PR until Blocker and Major findings are resolved.
+- **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
+- **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. Leaving boxes unchecked causes CI to fail — this is intentional: it means the review was not completed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,116 @@
+# Isolate UI — Copilot Coding Instructions
+
+These rules apply to all code generated or edited by Copilot in this repository.
+Follow them precisely; do not silently deviate.
+
+---
+
+## Async / Error Handling
+
+- **No fire-and-forget.** Every top-level async call site must either `await` the call inside a `try/catch`, or chain `.catch()` with a handler that logs and exits (or re-throws). This applies to: command handlers (`approve.ts`, `fix.ts`, `query.ts`), startup functions, and any background work initiated from a route handler.
+- Mid-level `async` functions that are themselves `await`-ed do not need their own `.catch()` — rejection propagates to the caller.
+- Fastify route handlers must either `throw` on error or call `reply.status(N).send(err)`. Never swallow an error silently.
+
+```typescript
+// ✅ correct — top-level entry point
+start().catch((err) => {
+  console.error('[service] fatal startup error:', err);
+  process.exit(1);
+});
+
+// ❌ wrong — unhandled rejection if start() throws
+start();
+```
+
+---
+
+## Security
+
+- **Webhook HMAC verification must happen before any payload parsing or business logic.** Never read `request.body` fields before the signature is confirmed valid.
+- **Authorization checks must precede business logic.** Verify the actor's role/permission before touching state, the database, or external services.
+- **No secrets or tokens in log output.** Use a redaction helper or log only the first/last N characters. Never log `GITHUB_TOKEN`, `WEBHOOK_SECRET`, or equivalent.
+- Environment variables required for the service to function must be validated at startup with an explicit `process.exit(1)` and a clear error message if absent.
+
+```typescript
+// ✅ correct order
+verifyHmac(request); // 1. verify signature
+checkAuthorization(actor); // 2. check permission
+await processCommand(payload); // 3. business logic
+
+// ❌ wrong order — processes payload before verifying identity
+await processCommand(payload);
+verifyHmac(request);
+```
+
+---
+
+## TypeScript
+
+- **No `any` at public API boundaries** (exported function parameters, return types, Zod schemas, HTTP route types). Use `unknown` with explicit type narrowing instead.
+- **New I/O boundaries must use Zod.** Any new HTTP route handler, database read, or environment variable block introduced after May 2026 must parse its input with a Zod schema. Existing `IssueCommentPayload`-style interfaces do not need to be retrofitted.
+- Use `as const` for literal enum-like values shared across modules.
+- Prefer explicit return types on exported functions.
+
+```typescript
+// ✅ new route — Zod schema
+const BodySchema = z.object({ command: z.string(), issueId: z.number() });
+const body = BodySchema.parse(request.body);
+
+// ❌ no validation — unknown shape at runtime
+const body = request.body as MyInterface;
+```
+
+---
+
+## Testing
+
+- Every new **exported function** must have at least one test covering the failure / error path, not only the happy path.
+- Every new **async function** must have at least one test that verifies what happens when the async operation rejects or throws.
+- Mock external dependencies (`Octokit`, SQLite DB, LLM clients) — never make real network calls in unit tests.
+- Test files live alongside source files or in `__tests__/` directories within the same project. Do not place tests outside the project boundary.
+
+```typescript
+// ✅ error path tested
+it('throws when GITHUB_TOKEN is missing', () => {
+  delete process.env.GITHUB_TOKEN;
+  expect(() => validateEnv()).toThrow('GITHUB_TOKEN');
+});
+```
+
+---
+
+## LangGraph / AI Orchestrator
+
+- **State mutations must be via the return object only.** Never mutate `state` directly inside a node function. Return a `Partial<AgentState>` with only the fields that changed.
+- Channel reducers handle merging — returning the full state causes duplicate data.
+
+```typescript
+// ✅ correct — return only what changed
+return { next_recipient: 'dev', signoffs: { po: true } };
+
+// ❌ wrong — direct mutation
+state.next_recipient = 'dev';
+return state;
+```
+
+---
+
+## SQLite
+
+- **Parameterized queries only.** Never interpolate user-supplied or externally-sourced values into a SQL string.
+- Use `INSERT OR IGNORE` for idempotent inserts (e.g., deduplication tables).
+
+```typescript
+// ✅ correct
+db.prepare('SELECT * FROM deliveries WHERE id = ?').get(deliveryId);
+
+// ❌ wrong — SQL injection risk
+db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
+```
+
+---
+
+## Project Structure
+
+- All imports between Nx projects must use the workspace aliases defined in `tsconfig.base.json` (e.g. `@isolate-ui/utils`, `@isolate-ui/tokens`). Never use relative paths that cross project boundaries.
+- Generated or build-output directories (`styled-system/`, `dist/`, `playwright/.cache/`) must never be committed or imported from source.

--- a/.github/prompts/pre-pr-review.prompt.md
+++ b/.github/prompts/pre-pr-review.prompt.md
@@ -1,0 +1,92 @@
+---
+mode: ask
+description: >
+  Pre-PR reviewer: inspects current changes against the project's coding standards
+  and outputs a severity-classified findings table. Run at the end of each phase
+  of work before opening or updating a pull request.
+---
+
+You are a thorough code reviewer for the Isolate UI monorepo. Review the current
+uncommitted changes (or the diff since the base branch if changes are already staged/committed)
+against the project's coding standards defined in `.github/copilot-instructions.md`.
+
+## Review checklist
+
+For **every file changed**, check each of the following categories. Only report findings
+that actually apply — do not manufacture findings.
+
+### 1. Async / Error Handling
+
+- Top-level async call sites (command handlers, startup functions, background work
+  initiated from route handlers) must use `.catch()` or `try/catch`. Flag any
+  fire-and-forget call where the returned promise is not handled.
+- Fastify route handlers must either `throw` or call `reply.status(N).send(err)`.
+  Flag any route that silently swallows an error.
+
+### 2. Security
+
+- HMAC / signature verification must occur before any payload field is read or
+  business logic runs. Flag any route that processes the body before verifying the signature.
+- Authorization checks (role / permission verification) must precede business logic.
+  Flag any handler that touches state or calls external services before checking the actor's permission.
+- Secrets, tokens, or sensitive env var values must not appear in log statements.
+  Flag any `console.log`, `logger.info`, etc. that could leak a credential.
+
+### 3. TypeScript
+
+- No `any` at public API boundaries (exported function signatures, Zod schemas, HTTP
+  route types). Flag uses of `any`; suggest `unknown` with type narrowing instead.
+- Any **new** HTTP route handler, database read, or env-var block must parse its input
+  with a Zod schema. Flag missing Zod validation on new I/O boundaries only — do not
+  flag existing `IssueCommentPayload`-style interfaces.
+
+### 4. Testing
+
+- Every new **exported function** must have at least one test covering the error / failure path.
+- Every new **async function** must have at least one test that verifies what happens when
+  the operation rejects or throws.
+- Flag any new exported or async function with no corresponding test file changes.
+
+### 5. LangGraph
+
+- LangGraph node functions must return a `Partial<AgentState>` with only changed fields.
+  Flag any direct mutation of the `state` argument inside a node function.
+
+### 6. SQLite
+
+- All SQL queries must use parameterized statements. Flag any string interpolation or
+  template-literal SQL that incorporates runtime values.
+
+### 7. Project structure
+
+- Cross-project imports must use `@isolate-ui/*` workspace aliases from `tsconfig.base.json`.
+  Flag any relative `../` path that crosses an Nx project boundary.
+
+---
+
+## Output format
+
+Produce a **Findings Table** followed by a **Summary**.
+
+### Findings Table
+
+| #   | File | Line(s) | Severity | Category | Description | Suggested fix |
+| --- | ---- | ------- | -------- | -------- | ----------- | ------------- |
+
+Severity levels (use exactly these labels):
+
+- **Blocker** — Security defect or correctness issue that must be fixed before merging
+- **Major** — Reliability or correctness issue; fix in this PR if low-effort, otherwise track as a follow-up issue
+- **Minor** — Coverage or completeness gap; open a follow-up issue
+- **Nit** — Style or naming; resolve with a written rationale, no code change required
+
+If there are **no findings** in a category, omit that category from the table entirely.
+If there are **no findings at all**, output: `✅ No findings — all checks passed.`
+
+### Summary
+
+After the table, output a one-paragraph plain-English summary:
+
+- How many findings per severity tier
+- Which areas are clean
+- Whether the changes are ready to proceed to the next phase or need fixes first

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
     name: Check PR Template
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Validate PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -77,20 +82,23 @@ jobs:
             process.exit(1);
           }
 
-          // All four triage checkboxes must be checked [x].
-          // Requiring exactly 4 checked boxes is robust against list-marker
-          // variations (- vs * vs +) and prevents bypassing by deleting lines.
+          // Each of the four required triage tiers must be explicitly checked [x].
+          // Matching per-tier name (Blocker/Major/Minor/Nit) prevents bypassing by
+          // adding arbitrary [x] tokens or deleting/renaming checkbox lines.
           const triageStart = body.indexOf('## Copilot Review Triage');
           const triageEnd = body.indexOf('## Deferred follow-ups');
           const triageSection = triageStart !== -1 && triageEnd !== -1
             ? body.slice(triageStart, triageEnd)
             : '';
 
-          const checkedBoxes = (triageSection.match(/\[x\]/gi) ?? []).length;
-          if (checkedBoxes < 4) {
-            console.error(
-              `PR triage section has ${checkedBoxes} checked box(es) — all 4 are required.`
-            );
+          const requiredTiers = ['Blocker', 'Major', 'Minor', 'Nit'];
+          const uncheckedTiers = requiredTiers.filter(
+            (tier) => !new RegExp(`\\[x\\][^\\n]*\\b${tier}\\b`, 'i').test(triageSection)
+          );
+
+          if (uncheckedTiers.length > 0) {
+            console.error('The following triage items are missing or unchecked in the PR:');
+            uncheckedTiers.forEach((t) => console.error('  ' + t));
             console.error(
               'Run #pre-pr-review in VS Code Copilot Chat and tick every triage checkbox before opening the PR.'
             );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,58 @@ jobs:
       - name: Typecheck affected
         run: pnpm nx affected -t typecheck --base=origin/main
 
+  check-pr-template:
+    name: Check PR Template
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          node - <<'EOF'
+          const body = process.env.PR_BODY ?? '';
+
+          const requiredSections = [
+            '## Summary',
+            '## Changes',
+            '## Copilot Review Triage',
+            '## Deferred follow-ups',
+          ];
+
+          const missingSections = requiredSections.filter(
+            (s) => !body.includes(s)
+          );
+
+          if (missingSections.length > 0) {
+            console.error('PR body is missing required sections:');
+            missingSections.forEach((s) => console.error('  ' + s));
+            console.error(
+              'Use the PR template (.github/PULL_REQUEST_TEMPLATE.md) when opening a PR.'
+            );
+            process.exit(1);
+          }
+
+          // Unchecked boxes inside the triage section means the review
+          // was not completed before opening the PR.
+          const triageStart = body.indexOf('## Copilot Review Triage');
+          const triageEnd = body.indexOf('## Deferred follow-ups');
+          const triageSection = triageStart !== -1 && triageEnd !== -1
+            ? body.slice(triageStart, triageEnd)
+            : '';
+
+          if (/^- \[ \]/m.test(triageSection)) {
+            console.error(
+              'PR has unchecked triage boxes in the Copilot Review Triage section.'
+            );
+            console.error(
+              'Run #pre-pr-review in VS Code Copilot Chat and resolve all findings before opening the PR.'
+            );
+            process.exit(1);
+          }
+
+          console.log('PR template check passed.');
+          EOF
+
   check-version-plan:
     name: Check Version Plan
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,20 +77,22 @@ jobs:
             process.exit(1);
           }
 
-          // Unchecked boxes inside the triage section means the review
-          // was not completed before opening the PR.
+          // All four triage checkboxes must be checked [x].
+          // Requiring exactly 4 checked boxes is robust against list-marker
+          // variations (- vs * vs +) and prevents bypassing by deleting lines.
           const triageStart = body.indexOf('## Copilot Review Triage');
           const triageEnd = body.indexOf('## Deferred follow-ups');
           const triageSection = triageStart !== -1 && triageEnd !== -1
             ? body.slice(triageStart, triageEnd)
             : '';
 
-          if (/^- \[ \]/m.test(triageSection)) {
+          const checkedBoxes = (triageSection.match(/\[x\]/gi) ?? []).length;
+          if (checkedBoxes < 4) {
             console.error(
-              'PR has unchecked triage boxes in the Copilot Review Triage section.'
+              `PR triage section has ${checkedBoxes} checked box(es) — all 4 are required.`
             );
             console.error(
-              'Run #pre-pr-review in VS Code Copilot Chat and resolve all findings before opening the PR.'
+              'Run #pre-pr-review in VS Code Copilot Chat and tick every triage checkbox before opening the PR.'
             );
             process.exit(1);
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,11 +254,10 @@ nx affected -t test lint typecheck build
 
 ### Pre-PR Review (mandatory, phase-gated)
 
-Run the local pre-PR reviewer **at the end of every phase of work** — not only before opening a PR. Open the VS Code Copilot Chat panel and run:
+The pre-PR reviewer **must run at the end of every phase of work** — not only before opening a PR. This is not optional and must not wait for a human to remember to trigger it.
 
-```
-#pre-pr-review
-```
+- **AI agents**: run `#pre-pr-review` automatically as part of phase completion, before reporting back or starting the next phase.
+- **Humans**: open the VS Code Copilot Chat panel and run `#pre-pr-review`.
 
 **Before starting the next phase:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,21 @@ nx run-many -t typecheck
 nx run-many -t lint
 ```
 
+### Starting an Issue
+
+At the start of every issue, create a new branch from `main`:
+
+```bash
+# Ensure main is up to date
+git checkout main && git pull
+
+# Create a branch named after the issue number and a short slug
+git checkout -b <issue-number>-<short-description>
+# e.g. git checkout -b 65-copilot-review-loop
+```
+
+All work for the issue happens on this branch. Open the PR against `main` when the final phase is complete and the pre-PR reviewer has been run.
+
 ### Daily Development
 
 ```bash
@@ -236,6 +251,48 @@ nx build react-button
 # Run all tasks for affected projects
 nx affected -t test lint typecheck build
 ```
+
+### Pre-PR Review (mandatory, phase-gated)
+
+Run the local pre-PR reviewer **at the end of every phase of work** — not only before opening a PR. Open the VS Code Copilot Chat panel and run:
+
+```
+#pre-pr-review
+```
+
+**Before starting the next phase:**
+
+- Fix all **Blocker** and **Major** findings.
+- For **Minor** findings: either fix inline or open a follow-up GitHub issue.
+- For **Nit** findings: resolve with a written rationale — no code change required.
+- Nothing opens a PR until the reviewer has been run on the final phase output.
+
+See [`.github/prompts/pre-pr-review.prompt.md`](.github/prompts/pre-pr-review.prompt.md) for the prompt definition.
+
+## PR Review Triage Policy
+
+This policy applies to all Copilot (and human) review comments. Its purpose is to prevent endless review cycles by giving every comment a clear, bounded resolution path.
+
+### Severity Tiers
+
+| Tier                                  | Examples                                                                                             | Resolution                                                                                                                                                |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Blocker** (Security / Correctness)  | HMAC bypass, unhandled promise rejection, auth check after business logic, secrets in logs           | Fix before merge — no exceptions.                                                                                                                         |
+| **Major** (Correctness / Reliability) | Missing error handler, incorrect async pattern, broken edge case, type unsafety at a public boundary | Fix in the same PR if low-effort. If out of scope, open a follow-up issue and link it in the PR description before merging.                               |
+| **Minor** (Coverage / Completeness)   | Missing test for an error path, uncovered edge case, missing Zod schema on a new I/O boundary        | Open a follow-up issue. Resolve the review thread with `tracked as #N`.                                                                                   |
+| **Nit** (Style / Naming)              | Variable naming, comment wording, minor formatting deviation                                         | Resolve the thread with a one-sentence written rationale (e.g. "intentional: consistent with existing pattern in `webhook.ts`"). No code change required. |
+
+### Resolution without a code change
+
+For Minor and Nit items: post a reply on the review thread explaining the decision, then resolve the thread. A commit is **not** required. This prevents the commit → re-review spiral.
+
+### Deferred follow-ups
+
+Any Major or Minor item deferred to a follow-up issue **must** be linked in the PR description before the PR is merged. Use the "Deferred follow-ups" section of the PR template.
+
+### No hard round limit
+
+There is no fixed maximum number of review cycles. Use the triage table to bound each comment individually. If a review cycle is generating many Blocker/Major findings, that signals a quality gap — run the pre-PR reviewer earlier in the next phase of work.
 
 ## Commit Message Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,21 @@ Run the local pre-PR reviewer **at the end of every phase of work** — not only
 
 See [`.github/prompts/pre-pr-review.prompt.md`](.github/prompts/pre-pr-review.prompt.md) for the prompt definition.
 
+### Opening a PR (mandatory)
+
+Every PR **must** use the PR template at [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). GitHub inserts it automatically when creating a PR via the web UI or `gh pr create`. **Do not delete or skip sections** — CI runs a `check-pr-template` job that fails the build if:
+
+- Any of the four required sections (`## Summary`, `## Changes`, `## Copilot Review Triage`, `## Deferred follow-ups`) is missing, or
+- Any triage checkbox is left unchecked (`- [ ]`).
+
+**Workflow before opening the PR:**
+
+1. Run `#pre-pr-review` in VS Code Copilot Chat.
+2. Resolve all findings (fix Blockers/Majors; track Minors as issues; rationale for Nits).
+3. Open the PR — GitHub fills in the template automatically.
+4. Tick triage checkboxes only for the tiers you have verified are clean.
+5. Link any deferred follow-up issues in the `## Deferred follow-ups` section.
+
 ## PR Review Triage Policy
 
 This policy applies to all Copilot (and human) review comments. Its purpose is to prevent endless review cycles by giving every comment a clear, bounded resolution path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,7 @@ See [`.github/prompts/pre-pr-review.prompt.md`](.github/prompts/pre-pr-review.pr
 Every PR **must** use the PR template at [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). GitHub inserts it automatically when creating a PR via the web UI or `gh pr create`. **Do not delete or skip sections** — CI runs a `check-pr-template` job that fails the build if:
 
 - Any of the four required sections (`## Summary`, `## Changes`, `## Copilot Review Triage`, `## Deferred follow-ups`) is missing, or
-- Any triage checkbox is left unchecked (`- [ ]`).
+- Any of the four triage tiers (Blocker, Major, Minor, Nit) is missing or unchecked (`[x]`) in the Copilot Review Triage section.
 
 **Workflow before opening the PR:**
 

--- a/docs/ark-ui-reference.json
+++ b/docs/ark-ui-reference.json
@@ -3,6 +3,7 @@
     "button": {
       "name": "Button",
       "arkPrimitive": "Button",
+      "htmlTag": "button",
       "parts": ["root"],
       "accessibility": {
         "role": "button",

--- a/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
@@ -1,0 +1,533 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type MockedFunction,
+} from 'vitest';
+import { execFile } from 'child_process';
+import * as fsPromises from 'fs/promises';
+
+// ── Module mocks (hoisted before imports) ────────────────────────────────────
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn((fn: unknown) => fn),
+}));
+
+vi.mock('fs/promises', () => ({
+  access: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+// ── Imports under test (after mocks) ─────────────────────────────────────────
+
+import {
+  resolveHtmlTag,
+  introspectGoldenSample,
+  runNxGenerator,
+  writeComponentFile,
+  writeRecipeFile,
+  writeStoriesFile,
+  writeComponentTestFile,
+  runBuildAndTest,
+  attemptAutoFix,
+  createDevBoilerplateNode,
+} from '../orchestrator/dev-node';
+import { createDefaultAgentState } from '../schema';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const WORKSPACE = '/workspace';
+const ARK_REF_PATH = `${WORKSPACE}/docs/ark-ui-reference.json`;
+
+const mockExecFile = execFile as unknown as MockedFunction<
+  (
+    cmd: string,
+    args: string[],
+    opts: object,
+  ) => Promise<{ stdout: string; stderr: string }>
+>;
+const mockAccess = fsPromises.access as MockedFunction<
+  typeof fsPromises.access
+>;
+const mockReadFile = fsPromises.readFile as MockedFunction<
+  typeof fsPromises.readFile
+>;
+const mockWriteFile = fsPromises.writeFile as MockedFunction<
+  typeof fsPromises.writeFile
+>;
+
+function makeArkRef(htmlTag?: string): string {
+  return JSON.stringify({
+    primitives: {
+      button: { name: 'Button', htmlTag: htmlTag ?? 'button' },
+    },
+  });
+}
+
+function makeRecipeContent(): string {
+  return `
+import { createSlotRecipe } from '@isolate-ui/utils';
+export const buttonRecipe = createSlotRecipe({
+  slots: ['root', 'label', 'icon', 'spinner'],
+  variants: {
+    variant: {
+      solid: { root: {} },
+      outline: { root: {} },
+      ghost: { root: {} },
+    },
+  },
+});
+`.trim();
+}
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    ...createDefaultAgentState(),
+    metadata: { component_name: 'checkbox', ...overrides },
+  };
+}
+
+// ── resolveHtmlTag ────────────────────────────────────────────────────────────
+
+describe('resolveHtmlTag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns htmlTag from ark-ui-reference.json when entry exists', async () => {
+    mockReadFile.mockResolvedValueOnce(makeArkRef('button') as never);
+    const tag = await resolveHtmlTag('button', ARK_REF_PATH);
+    expect(tag).toBe('button');
+  });
+
+  it('returns componentName when it is a valid HTML tag and no ref entry', async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ primitives: {} }) as never,
+    );
+    const tag = await resolveHtmlTag('nav', ARK_REF_PATH);
+    expect(tag).toBe('nav');
+  });
+
+  it('falls back to div when componentName is not a valid HTML tag and no ref entry', async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ primitives: {} }) as never,
+    );
+    const tag = await resolveHtmlTag('datepicker', ARK_REF_PATH);
+    expect(tag).toBe('div');
+  });
+
+  it('falls back to div when ark-ui-reference.json read fails', async () => {
+    mockReadFile.mockRejectedValueOnce(new Error('ENOENT') as never);
+    const tag = await resolveHtmlTag('datepicker', ARK_REF_PATH);
+    expect(tag).toBe('div');
+  });
+
+  it('falls back to div when ark-ui-reference.json contains invalid JSON', async () => {
+    mockReadFile.mockResolvedValueOnce('not valid json' as never);
+    const tag = await resolveHtmlTag('datepicker', ARK_REF_PATH);
+    expect(tag).toBe('div');
+  });
+});
+
+// ── introspectGoldenSample ────────────────────────────────────────────────────
+
+describe('introspectGoldenSample', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns slot and variant names when all files are present', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile.mockResolvedValueOnce(makeRecipeContent() as never);
+
+    const patterns = await introspectGoldenSample(WORKSPACE);
+
+    expect(patterns.slots).toEqual(['root', 'label', 'icon', 'spinner']);
+    expect(patterns.variants).toEqual(['solid', 'outline', 'ghost']);
+  });
+
+  it('throws REJECTED: golden sample incomplete when a file is missing', async () => {
+    mockAccess.mockRejectedValueOnce(new Error('ENOENT') as never);
+
+    await expect(introspectGoldenSample(WORKSPACE)).rejects.toThrow(
+      'REJECTED: golden sample incomplete',
+    );
+  });
+
+  it('uses default slots when recipe has no slots array', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile.mockResolvedValueOnce(
+      'export const r = createSlotRecipe({});' as never,
+    );
+
+    const patterns = await introspectGoldenSample(WORKSPACE);
+    expect(patterns.slots).toEqual(['root', 'label']);
+  });
+
+  it('uses default variants when recipe has no variant block', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile.mockResolvedValueOnce(
+      "import { createSlotRecipe } from '@isolate-ui/utils';\nexport const r = createSlotRecipe({ slots: ['root'] });" as never,
+    );
+
+    const patterns = await introspectGoldenSample(WORKSPACE);
+    expect(patterns.variants).toEqual(['solid', 'outline', 'ghost']);
+  });
+});
+
+// ── runNxGenerator ────────────────────────────────────────────────────────────
+
+describe('runNxGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls execFileAsync with the correct mandatory flags', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: 'ok', stderr: '' } as never);
+
+    await runNxGenerator(WORKSPACE, 'checkbox');
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'pnpm',
+      expect.arrayContaining([
+        '--publishable',
+        '--importPath=@isolate-ui/checkbox',
+        '--directory=libs/react/checkbox',
+      ]),
+      expect.objectContaining({ cwd: WORKSPACE }),
+    );
+  });
+
+  it('rejects when execFile rejects', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('generator failed') as never);
+    await expect(runNxGenerator(WORKSPACE, 'checkbox')).rejects.toThrow(
+      'generator failed',
+    );
+  });
+});
+
+// ── writeComponentFile ────────────────────────────────────────────────────────
+
+describe('writeComponentFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes a file containing HTMLArkProps and ark.<tagName>', async () => {
+    await writeComponentFile('/dir', 'checkbox', 'input', ['root', 'label']);
+
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain("HTMLArkProps<'input'>");
+    expect(content).toContain('ark.input');
+  });
+
+  it('uses PascalCase for the component name', async () => {
+    await writeComponentFile('/dir', 'my-component', 'div', ['root']);
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('MyComponent');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('EACCES') as never);
+    await expect(
+      writeComponentFile('/dir', 'checkbox', 'input', ['root']),
+    ).rejects.toThrow('EACCES');
+  });
+});
+
+// ── writeRecipeFile ───────────────────────────────────────────────────────────
+
+describe('writeRecipeFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes a file importing createSlotRecipe with the given slots and variants', async () => {
+    await writeRecipeFile(
+      '/dir',
+      'checkbox',
+      ['root', 'label'],
+      ['solid', 'outline'],
+    );
+
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain("from '@isolate-ui/utils'");
+    expect(content).toContain("'root', 'label'");
+    expect(content).toContain('solid');
+    expect(content).toContain('outline');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('disk full') as never);
+    await expect(
+      writeRecipeFile('/dir', 'checkbox', ['root'], ['solid']),
+    ).rejects.toThrow('disk full');
+  });
+});
+
+// ── writeStoriesFile ──────────────────────────────────────────────────────────
+
+describe('writeStoriesFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes Default and AllVariants CSF 3.0 stories', async () => {
+    await writeStoriesFile('/dir', 'checkbox', ['solid', 'outline']);
+
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('export const Default');
+    expect(content).toContain('export const AllVariants');
+    expect(content).toContain('variant="solid"');
+    expect(content).toContain('variant="outline"');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('EACCES') as never);
+    await expect(
+      writeStoriesFile('/dir', 'checkbox', ['solid']),
+    ).rejects.toThrow('EACCES');
+  });
+});
+
+// ── writeComponentTestFile ────────────────────────────────────────────────────
+
+describe('writeComponentTestFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes a CT test importing from @isolate-ui/utils/a11y', async () => {
+    await writeComponentTestFile('/dir', 'checkbox');
+
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('@isolate-ui/utils/a11y');
+    expect(content).toContain('expectToHaveNoA11yViolations');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('ENOENT') as never);
+    await expect(writeComponentTestFile('/dir', 'checkbox')).rejects.toThrow(
+      'ENOENT',
+    );
+  });
+});
+
+// ── runBuildAndTest ───────────────────────────────────────────────────────────
+
+describe('runBuildAndTest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns success: true when both build and test pass', async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never);
+
+    const result = await runBuildAndTest(WORKSPACE, 'checkbox');
+    expect(result.success).toBe(true);
+    expect(result.errorLog).toBe('');
+  });
+
+  it('returns success: false with errorLog when build fails', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('build error') as never);
+
+    const result = await runBuildAndTest(WORKSPACE, 'checkbox');
+    expect(result.success).toBe(false);
+    expect(result.errorLog).toContain('build error');
+  });
+
+  it('returns success: false with errorLog when test fails', async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never)
+      .mockRejectedValueOnce(new Error('test failure') as never);
+
+    const result = await runBuildAndTest(WORKSPACE, 'checkbox');
+    expect(result.success).toBe(false);
+    expect(result.errorLog).toContain('test failure');
+  });
+});
+
+// ── attemptAutoFix ────────────────────────────────────────────────────────────
+
+describe('attemptAutoFix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns success: true when panda codegen succeeds', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' } as never);
+
+    const result = await attemptAutoFix(WORKSPACE, 'checkbox', 'some error');
+    expect(result.success).toBe(true);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'pnpm',
+      ['exec', 'panda', 'codegen'],
+      expect.objectContaining({ cwd: WORKSPACE }),
+    );
+  });
+
+  it('returns success: false when panda codegen fails', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('codegen failed') as never);
+
+    const result = await attemptAutoFix(WORKSPACE, 'checkbox', 'build error');
+    expect(result.success).toBe(false);
+    expect(result.errorLog).toContain('codegen failed');
+  });
+});
+
+// ── createDevBoilerplateNode ──────────────────────────────────────────────────
+
+describe('createDevBoilerplateNode', () => {
+  const config = { workspaceRoot: WORKSPACE };
+
+  function setupHappyPath() {
+    // introspectGoldenSample: all files accessible + recipe readable
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never) // recipe (introspect)
+      .mockResolvedValueOnce(makeArkRef() as never); // ark-ui-reference.json (resolveHtmlTag)
+    // runNxGenerator + build + test
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx build
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never); // nx test
+    // writeFile calls
+    mockWriteFile.mockResolvedValue(undefined as never);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('happy path: returns APPROVED message and sets code_buffer', async () => {
+    setupHappyPath();
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/APPROVED/);
+    expect(result.code_buffer).toBeTruthy();
+  });
+
+  it('build fails, auto-fix succeeds: returns APPROVED after retry', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockWriteFile.mockResolvedValue(undefined as never);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockRejectedValueOnce(new Error('build fail') as never) // nx build (first attempt)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // panda codegen (auto-fix)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx build (retry)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never); // nx test (retry)
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/APPROVED/);
+  });
+
+  it('build fails, auto-fix also fails: escalates to human_review', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockWriteFile.mockResolvedValue(undefined as never);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockRejectedValueOnce(new Error('build fail') as never) // nx build
+      .mockRejectedValueOnce(new Error('panda fail') as never); // panda codegen
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    expect(result.next_recipient).toBe('human_review');
+    expect(result.pause_context).toBe('mesh_stalemate');
+    expect(result.mesh_origin).toBe('dev');
+  });
+
+  it('build fails, auto-fix runs but retry build also fails: escalates to human_review', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockWriteFile.mockResolvedValue(undefined as never);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockRejectedValueOnce(new Error('build fail') as never) // nx build (first)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // panda codegen
+      .mockRejectedValueOnce(new Error('retry fail') as never); // nx build (retry)
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    expect(result.next_recipient).toBe('human_review');
+    expect(result.pause_context).toBe('mesh_stalemate');
+  });
+
+  it('missing component_name: returns REJECTED message', async () => {
+    const node = createDevBoilerplateNode(config);
+    const state = { ...createDefaultAgentState(), metadata: {} };
+    const result = await node(state);
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED: missing component_name/);
+    expect(result.next_recipient).toBeUndefined();
+  });
+
+  it('golden sample missing a file: returns REJECTED message', async () => {
+    mockAccess.mockRejectedValueOnce(new Error('ENOENT') as never);
+    mockReadFile.mockResolvedValueOnce(makeArkRef() as never);
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED: golden sample incomplete/);
+  });
+
+  it('Nx generator throws: returns REJECTED message', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockExecFile.mockRejectedValueOnce(new Error('nx error') as never);
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED:/);
+    expect(lastMessage?.content).toContain('nx error');
+  });
+
+  it('does not mutate state directly', async () => {
+    setupHappyPath();
+
+    const node = createDevBoilerplateNode(config);
+    const state = makeState();
+    const originalMessages = state.messages;
+
+    await node(state);
+
+    // state.messages should be unchanged (node returns new array)
+    expect(state.messages).toBe(originalMessages);
+  });
+});

--- a/libs/ai-orchestrator/src/orchestrator/dev-node.ts
+++ b/libs/ai-orchestrator/src/orchestrator/dev-node.ts
@@ -1,0 +1,653 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { AgentState, SerializedMessage } from '../schema';
+import type { AgentNodeFn } from './langgraph';
+
+const execFileAsync = promisify(execFile);
+
+// ── Public Types ──────────────────────────────────────────────────────────────
+
+export interface DevNodeConfig {
+  workspaceRoot: string;
+  /** Override the golden sample directory (defaults to libs/react/button/src/lib). */
+  goldenSamplePath?: string;
+}
+
+export interface GoldenSamplePatterns {
+  slots: string[];
+  variants: string[];
+}
+
+// ── HTML Tag Resolution ───────────────────────────────────────────────────────
+
+const VALID_HTML_TAGS = new Set([
+  'a',
+  'abbr',
+  'address',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'blockquote',
+  'button',
+  'canvas',
+  'caption',
+  'cite',
+  'code',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dialog',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'embed',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hr',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'main',
+  'map',
+  'mark',
+  'menu',
+  'meter',
+  'nav',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'picture',
+  'pre',
+  'progress',
+  'q',
+  'section',
+  'select',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'tr',
+  'ul',
+  'var',
+  'video',
+]);
+
+interface ArkRefEntry {
+  htmlTag?: string;
+}
+
+interface ArkRef {
+  primitives?: Record<string, ArkRefEntry>;
+}
+
+/**
+ * Resolve the HTML element tag for `HTMLArkProps<T>` and `ark.<tag>`.
+ *
+ * Lookup order:
+ * 1. docs/ark-ui-reference.json `htmlTag` field for the matching component entry
+ * 2. componentName is itself a valid HTML element tag
+ * 3. Fall back to 'div'
+ */
+export async function resolveHtmlTag(
+  componentName: string,
+  arkRefPath: string,
+): Promise<string> {
+  try {
+    const raw = await fs.readFile(arkRefPath, 'utf-8');
+    const ref = JSON.parse(raw) as ArkRef;
+    const entry = ref.primitives?.[componentName.toLowerCase()];
+    if (entry?.htmlTag) {
+      return entry.htmlTag;
+    }
+  } catch {
+    // File unreadable or JSON parse failure — fall through to next strategy.
+  }
+
+  if (VALID_HTML_TAGS.has(componentName.toLowerCase())) {
+    return componentName.toLowerCase();
+  }
+
+  return 'div';
+}
+
+// ── Golden Sample Introspection ───────────────────────────────────────────────
+
+/**
+ * Validates that all four required golden sample files exist, then reads them
+ * to extract slot names and recipe variant names.
+ *
+ * Throws with message 'REJECTED: golden sample incomplete' if any file is absent.
+ */
+export async function introspectGoldenSample(
+  workspaceRoot: string,
+  goldenSamplePath?: string,
+): Promise<GoldenSamplePatterns> {
+  const libBase =
+    goldenSamplePath ??
+    path.join(workspaceRoot, 'libs', 'react', 'button', 'src', 'lib');
+  const projectJson = path.join(
+    workspaceRoot,
+    'libs',
+    'react',
+    'button',
+    'project.json',
+  );
+
+  const requiredFiles = [
+    path.join(libBase, 'button.tsx'),
+    path.join(libBase, 'button.recipe.ts'),
+    path.join(libBase, 'button.ct.tsx'),
+    projectJson,
+  ];
+
+  for (const file of requiredFiles) {
+    try {
+      await fs.access(file);
+    } catch {
+      throw new Error('REJECTED: golden sample incomplete');
+    }
+  }
+
+  const recipeContent = await fs.readFile(
+    path.join(libBase, 'button.recipe.ts'),
+    'utf-8',
+  );
+
+  // Extract slot names: slots: ['root', 'label', ...]
+  const slotsMatch = recipeContent.match(/slots:\s*\[([^\]]+)\]/);
+  const slots = slotsMatch
+    ? slotsMatch[1]
+        .split(',')
+        .map((s) => s.trim().replace(/['"]/g, ''))
+        .filter(Boolean)
+    : ['root', 'label'];
+
+  // Extract variant names from the variants.variant block (6-space indented keys)
+  const variantMatches = [...recipeContent.matchAll(/^ {6}(\w+):\s*\{/gm)];
+  const variants =
+    variantMatches.length > 0
+      ? variantMatches.map((m) => m[1])
+      : ['solid', 'outline', 'ghost'];
+
+  return { slots, variants };
+}
+
+// ── Nx Generator ─────────────────────────────────────────────────────────────
+
+/**
+ * Runs `pnpm nx generate @nx/react:lib` for a new component library.
+ * --publishable and --importPath are mandatory to match monorepo conventions.
+ */
+export async function runNxGenerator(
+  workspaceRoot: string,
+  componentName: string,
+): Promise<{ stdout: string; stderr: string }> {
+  const { stdout, stderr } = await execFileAsync(
+    'pnpm',
+    [
+      'nx',
+      'generate',
+      '@nx/react:lib',
+      componentName,
+      `--directory=libs/react/${componentName}`,
+      '--unitTestRunner=vitest',
+      '--bundler=vite',
+      '--linter=eslint',
+      '--publishable',
+      `--importPath=@isolate-ui/${componentName}`,
+    ],
+    { cwd: workspaceRoot },
+  );
+  return { stdout, stderr };
+}
+
+// ── File Writers ──────────────────────────────────────────────────────────────
+
+/**
+ * Writes the main component TSX file using HTMLArkProps and ark.<tagName>.
+ */
+export async function writeComponentFile(
+  dir: string,
+  componentName: string,
+  tagName: string,
+  slots: string[],
+): Promise<void> {
+  const pascal = toPascal(componentName);
+  void slots; // slots inform recipe structure; component renders root + label
+
+  const content = [
+    `import type { HTMLArkProps } from '@ark-ui/react';`,
+    `import { ark } from '@ark-ui/react';`,
+    `import { cx } from 'styled-system/css';`,
+    `import { ${componentName}Recipe, type ${pascal}RecipeVariants } from './${componentName}.recipe';`,
+    ``,
+    `export type ${pascal}Props = HTMLArkProps<'${tagName}'> & {`,
+    `  /** Visual style variant. */`,
+    `  variant?: ${pascal}RecipeVariants['variant'];`,
+    `};`,
+    ``,
+    `export function ${pascal}({`,
+    `  children,`,
+    `  className,`,
+    `  variant,`,
+    `  ...props`,
+    `}: ${pascal}Props) {`,
+    `  const styles = ${componentName}Recipe({ variant });`,
+    ``,
+    `  return (`,
+    `    <ark.${tagName}`,
+    `      {...props}`,
+    `      className={cx(styles.root, className)}`,
+    `    >`,
+    `      <span className={styles.label}>{children}</span>`,
+    `    </ark.${tagName}>`,
+    `  );`,
+    `}`,
+    ``,
+    `export default ${pascal};`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(path.join(dir, `${componentName}.tsx`), content, 'utf-8');
+}
+
+/**
+ * Writes the Panda CSS slot recipe file using createSlotRecipe from @isolate-ui/utils.
+ */
+export async function writeRecipeFile(
+  dir: string,
+  componentName: string,
+  slots: string[],
+  variants: string[],
+): Promise<void> {
+  const pascal = toPascal(componentName);
+  const slotsArray = slots.map((s) => `'${s}'`).join(', ');
+  const defaultVariant = variants[0] ?? 'default';
+
+  const variantEntries = variants
+    .map((v) => `      ${v}: {\n        root: {},\n      },`)
+    .join('\n');
+
+  const content = [
+    `import { createSlotRecipe } from '@isolate-ui/utils';`,
+    ``,
+    `export const ${componentName}Recipe = createSlotRecipe({`,
+    `  className: '${componentName}',`,
+    `  slots: [${slotsArray}],`,
+    `  base: {`,
+    `    root: {`,
+    `      display: 'inline-flex',`,
+    `      alignItems: 'center',`,
+    `    },`,
+    `    label: {`,
+    `      lineHeight: 'normal',`,
+    `    },`,
+    `  },`,
+    `  variants: {`,
+    `    variant: {`,
+    variantEntries,
+    `    },`,
+    `  },`,
+    `  defaultVariants: {`,
+    `    variant: '${defaultVariant}',`,
+    `  },`,
+    `});`,
+    ``,
+    `export type ${pascal}RecipeVariants = NonNullable<`,
+    `  Parameters<typeof ${componentName}Recipe>[0]`,
+    `>;`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(
+    path.join(dir, `${componentName}.recipe.ts`),
+    content,
+    'utf-8',
+  );
+}
+
+/**
+ * Writes a CSF 3.0 Storybook stories file with Default and AllVariants stories.
+ * AllVariants is a static render templated from the variants array — no dynamic import.
+ */
+export async function writeStoriesFile(
+  dir: string,
+  componentName: string,
+  variants: string[],
+): Promise<void> {
+  const pascal = toPascal(componentName);
+
+  const allVariantsJsx = variants
+    .map((v) => `      <${pascal} variant="${v}">${pascal} ${v}</${pascal}>`)
+    .join('\n');
+
+  const content = [
+    `import type { Meta, StoryObj } from '@storybook/react';`,
+    `import { ${pascal} } from './${componentName}';`,
+    ``,
+    `const meta: Meta<typeof ${pascal}> = {`,
+    `  title: 'React/${pascal}',`,
+    `  component: ${pascal},`,
+    `  tags: ['autodocs'],`,
+    `  parameters: {`,
+    `    layout: 'centered',`,
+    `  },`,
+    `};`,
+    ``,
+    `export default meta;`,
+    `type Story = StoryObj<typeof meta>;`,
+    ``,
+    `export const Default: Story = {`,
+    `  args: {`,
+    `    children: '${pascal}',`,
+    `  },`,
+    `};`,
+    ``,
+    `export const AllVariants: Story = {`,
+    `  render: () => (`,
+    `    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>`,
+    allVariantsJsx,
+    `    </div>`,
+    `  ),`,
+    `};`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(
+    path.join(dir, `${componentName}.stories.tsx`),
+    content,
+    'utf-8',
+  );
+}
+
+/**
+ * Writes a Playwright CT test file mirroring the golden sample pattern.
+ */
+export async function writeComponentTestFile(
+  dir: string,
+  componentName: string,
+): Promise<void> {
+  const pascal = toPascal(componentName);
+
+  const content = [
+    `import { expect, test } from '@playwright/experimental-ct-react';`,
+    `import { expectToHaveNoA11yViolations } from '@isolate-ui/utils/a11y';`,
+    `import ${pascal} from './${componentName}';`,
+    ``,
+    `test('renders and is visible', async ({ mount }) => {`,
+    `  const component = await mount(<${pascal}>${pascal}</${pascal}>);`,
+    `  await expect(component).toBeVisible();`,
+    `});`,
+    ``,
+    `test('passes a11y in default state', async ({ mount }) => {`,
+    `  const component = await mount(<${pascal}>${pascal}</${pascal}>);`,
+    `  await expectToHaveNoA11yViolations(component);`,
+    `});`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(
+    path.join(dir, `${componentName}.ct.tsx`),
+    content,
+    'utf-8',
+  );
+}
+
+// ── Build & Test ──────────────────────────────────────────────────────────────
+
+/**
+ * Runs `pnpm nx build` then `pnpm nx test` for the generated component.
+ */
+export async function runBuildAndTest(
+  workspaceRoot: string,
+  componentName: string,
+): Promise<{ success: boolean; errorLog: string }> {
+  const projectName = `react-${componentName}`;
+  try {
+    await execFileAsync('pnpm', ['nx', 'build', projectName], {
+      cwd: workspaceRoot,
+    });
+    await execFileAsync('pnpm', ['nx', 'test', projectName, '--', '--run'], {
+      cwd: workspaceRoot,
+    });
+    return { success: true, errorLog: '' };
+  } catch (err) {
+    const errorLog = err instanceof Error ? err.message : String(err);
+    return { success: false, errorLog };
+  }
+}
+
+/**
+ * Infrastructure-only auto-fix: re-runs Panda CSS codegen to refresh styled-system/.
+ * Does NOT patch generated source files.
+ */
+export async function attemptAutoFix(
+  workspaceRoot: string,
+  _componentName: string,
+  _errorLog: string,
+): Promise<{ success: boolean; errorLog: string }> {
+  try {
+    await execFileAsync('pnpm', ['exec', 'panda', 'codegen'], {
+      cwd: workspaceRoot,
+    });
+    return { success: true, errorLog: '' };
+  } catch (err) {
+    const errorLog = err instanceof Error ? err.message : String(err);
+    return { success: false, errorLog };
+  }
+}
+
+// ── Main Node Factory ─────────────────────────────────────────────────────────
+
+/**
+ * Creates the dev persona node function for component boilerplate generation.
+ *
+ * Flow:
+ * 1. Validate component_name in metadata — REJECTED if missing
+ * 2. Introspect golden sample — REJECTED if files absent
+ * 3. Resolve HTML tag via ark-ui-reference.json
+ * 4. Run Nx generator
+ * 5. Write component, recipe, stories, and CT test files
+ * 6. Run build + test — APPROVED if successful
+ * 7. Attempt Panda codegen auto-fix — APPROVED if subsequent build passes
+ * 8. Escalate to human_review with pause_context: 'mesh_stalemate' if auto-fix fails
+ */
+export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
+  return async (state: AgentState): Promise<Partial<AgentState>> => {
+    const componentName = state.metadata?.['component_name'] as
+      | string
+      | undefined;
+
+    if (!componentName) {
+      return {
+        messages: [
+          ...state.messages,
+          makeMessage(
+            'Component generation skipped: no component_name in metadata.\n\nREJECTED: missing component_name',
+          ),
+        ],
+      };
+    }
+
+    const slots = state.parts.length > 0 ? state.parts : ['root', 'label'];
+
+    // 1. Validate golden sample
+    let patterns: GoldenSamplePatterns;
+    try {
+      patterns = await introspectGoldenSample(
+        config.workspaceRoot,
+        config.goldenSamplePath,
+      );
+    } catch (err) {
+      const reason =
+        err instanceof Error ? err.message : 'golden sample incomplete';
+      const message = reason.startsWith('REJECTED:')
+        ? reason
+        : `REJECTED: ${reason}`;
+      return {
+        messages: [...state.messages, makeMessage(message)],
+      };
+    }
+
+    const { variants } = patterns;
+
+    // 2. Resolve HTML tag
+    const arkRefPath = path.join(
+      config.workspaceRoot,
+      'docs',
+      'ark-ui-reference.json',
+    );
+    const tagName = await resolveHtmlTag(componentName, arkRefPath);
+
+    // 3. Run Nx generator
+    try {
+      await runNxGenerator(config.workspaceRoot, componentName);
+    } catch (err) {
+      const errorLog = err instanceof Error ? err.message : String(err);
+      return {
+        messages: [
+          ...state.messages,
+          makeMessage(`Nx generator failed.\n\nREJECTED: ${errorLog}`),
+        ],
+      };
+    }
+
+    // 4. Write boilerplate files
+    const dir = path.join(
+      config.workspaceRoot,
+      'libs',
+      'react',
+      componentName,
+      'src',
+      'lib',
+    );
+    try {
+      await writeComponentFile(dir, componentName, tagName, slots);
+      await writeRecipeFile(dir, componentName, slots, variants);
+      await writeStoriesFile(dir, componentName, variants);
+      await writeComponentTestFile(dir, componentName);
+    } catch (err) {
+      const errorLog = err instanceof Error ? err.message : String(err);
+      return {
+        messages: [
+          ...state.messages,
+          makeMessage(`File write failed.\n\nREJECTED: ${errorLog}`),
+        ],
+      };
+    }
+
+    // 5. Build + test
+    const buildResult = await runBuildAndTest(
+      config.workspaceRoot,
+      componentName,
+    );
+    if (buildResult.success) {
+      return {
+        code_buffer: dir,
+        messages: [
+          ...state.messages,
+          makeMessage(
+            `Component \`${componentName}\` generated and verified.\n\nAPPROVED`,
+          ),
+        ],
+      };
+    }
+
+    // 6. Auto-fix (Panda codegen only)
+    const fixResult = await attemptAutoFix(
+      config.workspaceRoot,
+      componentName,
+      buildResult.errorLog,
+    );
+    if (fixResult.success) {
+      const retryResult = await runBuildAndTest(
+        config.workspaceRoot,
+        componentName,
+      );
+      if (retryResult.success) {
+        return {
+          code_buffer: dir,
+          messages: [
+            ...state.messages,
+            makeMessage(
+              `Component \`${componentName}\` generated and verified after auto-fix.\n\nAPPROVED`,
+            ),
+          ],
+        };
+      }
+      // Auto-fix ran but retry still failed — use retry's error log for escalation
+      return escalate(state, componentName, retryResult.errorLog);
+    }
+
+    // 7. Escalate: auto-fix itself failed
+    return escalate(state, componentName, buildResult.errorLog);
+  };
+}
+
+// ── Private Helpers ───────────────────────────────────────────────────────────
+
+function escalate(
+  state: AgentState,
+  componentName: string,
+  errorLog: string,
+): Partial<AgentState> {
+  return {
+    next_recipient: 'human_review',
+    pause_context: 'mesh_stalemate',
+    mesh_origin: 'dev',
+    messages: [
+      ...state.messages,
+      makeMessage(
+        `Component \`${componentName}\` generation failed after auto-fix attempt.\n\n` +
+          `Error:\n${errorLog}\n\n` +
+          `REJECTED: auto-fix failed`,
+      ),
+    ],
+  };
+}
+
+function toPascal(name: string): string {
+  return name
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function makeMessage(content: string): SerializedMessage {
+  return { type: 'ai', content };
+}

--- a/libs/ai-orchestrator/src/orchestrator/index.ts
+++ b/libs/ai-orchestrator/src/orchestrator/index.ts
@@ -40,3 +40,19 @@ export {
   type ApplyCodeBufferSuccess,
   type ApplyCodeBufferFailure,
 } from './git-utils';
+
+// Dev boilerplate node
+export {
+  createDevBoilerplateNode,
+  introspectGoldenSample,
+  resolveHtmlTag,
+  runNxGenerator,
+  writeComponentFile,
+  writeRecipeFile,
+  writeStoriesFile,
+  writeComponentTestFile,
+  runBuildAndTest,
+  attemptAutoFix,
+  type DevNodeConfig,
+  type GoldenSamplePatterns,
+} from './dev-node';

--- a/libs/ai-orchestrator/src/orchestrator/langgraph.ts
+++ b/libs/ai-orchestrator/src/orchestrator/langgraph.ts
@@ -162,6 +162,10 @@ export class OrchestratorGraph {
           value: (x: any, y: any) => (y !== undefined ? y : x),
           default: () => null,
         },
+        parts: {
+          value: (x: any, y: any) => (y !== undefined ? y : x),
+          default: () => [],
+        },
       },
     });
 

--- a/libs/ai-orchestrator/src/schema/agent-state.ts
+++ b/libs/ai-orchestrator/src/schema/agent-state.ts
@@ -131,6 +131,13 @@ export const AgentStateSchema = z.object({
     .enum(['refinement_limit', 'mesh_stalemate'])
     .nullable()
     .default(null),
+
+  /**
+   * Component slot names to generate for the new component.
+   * Populated by the dev node from the incoming request or defaulted to
+   * ['root', 'label'] when absent. Used to drive recipe and boilerplate generation.
+   */
+  parts: z.array(z.string()).default(() => []),
 });
 
 export type AgentState = z.infer<typeof AgentStateSchema>;
@@ -153,6 +160,7 @@ export const DEFAULT_AGENT_STATE: AgentState = {
   mesh_loop_count: 0,
   mesh_origin: null,
   pause_context: null,
+  parts: [],
 };
 
 /**
@@ -176,5 +184,6 @@ export function createDefaultAgentState(): AgentState {
     mesh_loop_count: 0,
     mesh_origin: null,
     pause_context: null,
+    parts: [],
   };
 }


### PR DESCRIPTION
## Summary

Implements the `dev` LangGraph node as a real component-generation node (Issue #22), replacing the no-op pass-through. The node introspects the button golden sample, runs `pnpm nx generate`, writes component boilerplate files, runs build + test, attempts a single Panda codegen auto-fix on failure, and escalates to `human_review` (`pause_context: 'mesh_stalemate'`) if auto-fix fails.

Also updates workflow process rules in `copilot-instructions.md` to require human sign-off and phase commits before proceeding.

## Changes

- `libs/ai-orchestrator/src/schema/agent-state.ts` — add `parts` field to `AgentStateSchema`, `DEFAULT_AGENT_STATE`, and `createDefaultAgentState()`
- `libs/ai-orchestrator/src/orchestrator/langgraph.ts` — add `parts` channel in `buildGraph()`
- `libs/ai-orchestrator/src/orchestrator/dev-node.ts` — new file: `resolveHtmlTag`, `introspectGoldenSample`, `runNxGenerator`, `writeComponentFile`, `writeRecipeFile`, `writeStoriesFile`, `writeComponentTestFile`, `runBuildAndTest`, `attemptAutoFix`, `createDevBoilerplateNode`
- `libs/ai-orchestrator/src/orchestrator/index.ts` — export all new symbols
- `libs/ai-orchestrator/src/__tests__/dev-node.spec.ts` — 33 new tests
- `docs/ark-ui-reference.json` — add `"htmlTag": "button"` to the `button` entry
- `.github/copilot-instructions.md` — add human sign-off and phase commit rules

## Copilot Review Triage

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.

## Deferred follow-ups

- Nit: `_errorLog` param in `attemptAutoFix` — intentional underscore; auto-fix runs panda codegen unconditionally regardless of error content. No code change required.