### PR TITLE
feat(ai-orchestrator): add component boilerplate dev node (issue #22)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,5 +120,7 @@ db.exec(`SELECT * FROM deliveries WHERE id = '${deliveryId}'`);
 ## PR Workflow
 
 - **Run the pre-PR reviewer automatically at the end of every phase of work.** Do not wait for a human to ask. In VS Code Copilot Chat, run `#pre-pr-review` and work through all findings before reporting phase completion or starting the next phase. Do not open the PR until Blocker and Major findings are resolved.
+- **Wait for explicit human sign-off before committing.** After presenting the pre-PR review findings, do not commit or proceed to the next phase until the human has reviewed and approved. Never auto-commit immediately after the review.
+- **Phase changes must be committed before the next phase begins.** Once the human has signed off, commit the phase changes (one commit per phase) before starting any implementation work for the subsequent phase.
 - **Always use the PR template.** Every PR must include the four required sections: `## Summary`, `## Changes`, `## Copilot Review Triage`, and `## Deferred follow-ups`. CI will fail if any section is missing.
 - **Never pre-check triage boxes.** Only mark a triage checkbox as `[x]` after the pre-PR review confirms that category is clean. CI requires all four triage checkboxes to be checked (`[x]`) and will fail if fewer than four are present — this is intentional: it means the review was not completed.

--- a/docs/ark-ui-reference.json
+++ b/docs/ark-ui-reference.json
@@ -3,6 +3,7 @@
     "button": {
       "name": "Button",
       "arkPrimitive": "Button",
+      "htmlTag": "button",
       "parts": ["root"],
       "accessibility": {
         "role": "button",

--- a/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
@@ -270,6 +270,13 @@ describe('writeComponentFile', () => {
     expect(content).toContain('MyComponent');
   });
 
+  it('uses camelCase for the recipe identifier (kebab-case input)', async () => {
+    await writeComponentFile('/dir', 'my-component', 'div', ['root']);
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('myComponentRecipe');
+    expect(content).not.toContain('my-componentRecipe');
+  });
+
   it('rejects when writeFile rejects', async () => {
     mockWriteFile.mockRejectedValueOnce(new Error('EACCES') as never);
     await expect(
@@ -299,6 +306,14 @@ describe('writeRecipeFile', () => {
     expect(content).toContain("'root', 'label'");
     expect(content).toContain('solid');
     expect(content).toContain('outline');
+  });
+
+  it('uses camelCase identifier for recipe export (kebab-case name)', async () => {
+    await writeRecipeFile('/dir', 'my-component', ['root'], ['solid']);
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('export const myComponentRecipe');
+    expect(content).not.toContain('my-componentRecipe');
+    expect(content).toContain('Parameters<typeof myComponentRecipe>');
   });
 
   it('rejects when writeFile rejects', async () => {
@@ -384,6 +399,16 @@ describe('runBuildAndTest', () => {
     expect(result.errorLog).toContain('build error');
   });
 
+  it('includes stderr in errorLog when execFile attaches it', async () => {
+    const err = Object.assign(new Error('failed'), {
+      stderr: 'TS2304: Cannot find name',
+    });
+    mockExecFile.mockRejectedValueOnce(err as never);
+
+    const result = await runBuildAndTest(WORKSPACE, 'checkbox');
+    expect(result.errorLog).toContain('TS2304: Cannot find name');
+  });
+
   it('returns success: false with errorLog when test fails', async () => {
     mockExecFile
       .mockResolvedValueOnce({ stdout: '', stderr: '' } as never)
@@ -420,6 +445,16 @@ describe('attemptAutoFix', () => {
     const result = await attemptAutoFix(WORKSPACE, 'checkbox', 'build error');
     expect(result.success).toBe(false);
     expect(result.errorLog).toContain('codegen failed');
+  });
+
+  it('includes stderr in errorLog when panda codegen attaches it', async () => {
+    const err = Object.assign(new Error('panda failed'), {
+      stderr: 'Error: missing token',
+    });
+    mockExecFile.mockRejectedValueOnce(err as never);
+
+    const result = await attemptAutoFix(WORKSPACE, 'checkbox', 'build error');
+    expect(result.errorLog).toContain('Error: missing token');
   });
 });
 
@@ -554,6 +589,35 @@ describe('createDevBoilerplateNode', () => {
     const result = await node(state);
 
     expect(result.code_buffer).toContain('Slots: root, label, icon');
+  });
+
+  it('rejects invalid slot name containing hyphen', async () => {
+    const node = createDevBoilerplateNode(config);
+    const state = { ...makeState(), parts: ['icon-wrapper'] };
+    const result = await node(state);
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED: slot name/);
+    expect(lastMessage?.content).toContain('icon-wrapper');
+  });
+
+  it('escalation message uses STALEMATE not REJECTED to avoid refinement wrapper override', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockWriteFile.mockResolvedValue(undefined as never);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockRejectedValueOnce(new Error('build fail') as never) // nx build
+      .mockRejectedValueOnce(new Error('panda fail') as never); // panda codegen
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toContain('STALEMATE');
+    expect(lastMessage?.content).not.toMatch(/^REJECTED/m);
   });
 
   it('golden sample missing a file: returns REJECTED message', async () => {

--- a/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
@@ -134,6 +134,27 @@ describe('resolveHtmlTag', () => {
     const tag = await resolveHtmlTag('datepicker', ARK_REF_PATH);
     expect(tag).toBe('div');
   });
+
+  it('falls back to next strategy when htmlTag in JSON is not a valid HTML element', async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({
+        primitives: { widget: { htmlTag: 'not-an-html-tag' } },
+      }) as never,
+    );
+    // 'widget' is also not a valid HTML tag, so falls back to 'div'
+    const tag = await resolveHtmlTag('widget', ARK_REF_PATH);
+    expect(tag).toBe('div');
+  });
+
+  it('normalises htmlTag from JSON to lowercase', async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({
+        primitives: { button: { htmlTag: 'BUTTON' } },
+      }) as never,
+    );
+    const tag = await resolveHtmlTag('button', ARK_REF_PATH);
+    expect(tag).toBe('button');
+  });
 });
 
 // ── introspectGoldenSample ────────────────────────────────────────────────────
@@ -179,6 +200,19 @@ describe('introspectGoldenSample', () => {
 
     const patterns = await introspectGoldenSample(WORKSPACE);
     expect(patterns.variants).toEqual(['solid', 'outline', 'ghost']);
+  });
+
+  it('derives projectJson path from goldenSamplePath override', async () => {
+    const customPath = '/custom/workspace/libs/react/custom/src/lib';
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile.mockResolvedValueOnce(makeRecipeContent() as never);
+
+    await introspectGoldenSample(WORKSPACE, customPath);
+
+    // project.json should be resolved two levels up from src/lib: custom/project.json
+    expect(mockAccess).toHaveBeenCalledWith(
+      expect.stringContaining('custom/project.json'),
+    );
   });
 });
 
@@ -421,7 +455,9 @@ describe('createDevBoilerplateNode', () => {
 
     const lastMessage = result.messages?.[result.messages.length - 1];
     expect(lastMessage?.content).toMatch(/APPROVED/);
-    expect(result.code_buffer).toBeTruthy();
+    expect(result.code_buffer).toContain('Generated component: `checkbox`');
+    expect(result.code_buffer).toContain('Slots:');
+    expect(result.code_buffer).toContain('Variants:');
   });
 
   it('build fails, auto-fix succeeds: returns APPROVED after retry', async () => {
@@ -490,6 +526,34 @@ describe('createDevBoilerplateNode', () => {
     const lastMessage = result.messages?.[result.messages.length - 1];
     expect(lastMessage?.content).toMatch(/REJECTED: missing component_name/);
     expect(result.next_recipient).toBeUndefined();
+  });
+
+  it('invalid component_name format: returns REJECTED', async () => {
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState({ component_name: 'Invalid_Name!' }));
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED: component_name must match/);
+    expect(result.next_recipient).toBeUndefined();
+  });
+
+  it('path-traversal component_name: returns REJECTED', async () => {
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState({ component_name: '../../../etc' }));
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED:/);
+    expect(result.next_recipient).toBeUndefined();
+  });
+
+  it('normalizes slots to always include root and label', async () => {
+    setupHappyPath();
+
+    const node = createDevBoilerplateNode(config);
+    const state = { ...makeState(), parts: ['icon'] };
+    const result = await node(state);
+
+    expect(result.code_buffer).toContain('Slots: root, label, icon');
   });
 
   it('golden sample missing a file: returns REJECTED message', async () => {

--- a/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
@@ -1,0 +1,533 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  type MockedFunction,
+} from 'vitest';
+import { execFile } from 'child_process';
+import * as fsPromises from 'fs/promises';
+
+// ── Module mocks (hoisted before imports) ────────────────────────────────────
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn((fn: unknown) => fn),
+}));
+
+vi.mock('fs/promises', () => ({
+  access: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+// ── Imports under test (after mocks) ─────────────────────────────────────────
+
+import {
+  resolveHtmlTag,
+  introspectGoldenSample,
+  runNxGenerator,
+  writeComponentFile,
+  writeRecipeFile,
+  writeStoriesFile,
+  writeComponentTestFile,
+  runBuildAndTest,
+  attemptAutoFix,
+  createDevBoilerplateNode,
+} from '../orchestrator/dev-node';
+import { createDefaultAgentState } from '../schema';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const WORKSPACE = '/workspace';
+const ARK_REF_PATH = `${WORKSPACE}/docs/ark-ui-reference.json`;
+
+const mockExecFile = execFile as unknown as MockedFunction<
+  (
+    cmd: string,
+    args: string[],
+    opts: object,
+  ) => Promise<{ stdout: string; stderr: string }>
+>;
+const mockAccess = fsPromises.access as MockedFunction<
+  typeof fsPromises.access
+>;
+const mockReadFile = fsPromises.readFile as MockedFunction<
+  typeof fsPromises.readFile
+>;
+const mockWriteFile = fsPromises.writeFile as MockedFunction<
+  typeof fsPromises.writeFile
+>;
+
+function makeArkRef(htmlTag?: string): string {
+  return JSON.stringify({
+    primitives: {
+      button: { name: 'Button', htmlTag: htmlTag ?? 'button' },
+    },
+  });
+}
+
+function makeRecipeContent(): string {
+  return `
+import { createSlotRecipe } from '@isolate-ui/utils';
+export const buttonRecipe = createSlotRecipe({
+  slots: ['root', 'label', 'icon', 'spinner'],
+  variants: {
+    variant: {
+      solid: { root: {} },
+      outline: { root: {} },
+      ghost: { root: {} },
+    },
+  },
+});
+`.trim();
+}
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    ...createDefaultAgentState(),
+    metadata: { component_name: 'checkbox', ...overrides },
+  };
+}
+
+// ── resolveHtmlTag ────────────────────────────────────────────────────────────
+
+describe('resolveHtmlTag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns htmlTag from ark-ui-reference.json when entry exists', async () => {
+    mockReadFile.mockResolvedValueOnce(makeArkRef('button') as never);
+    const tag = await resolveHtmlTag('button', ARK_REF_PATH);
+    expect(tag).toBe('button');
+  });
+
+  it('returns componentName when it is a valid HTML tag and no ref entry', async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ primitives: {} }) as never,
+    );
+    const tag = await resolveHtmlTag('nav', ARK_REF_PATH);
+    expect(tag).toBe('nav');
+  });
+
+  it('falls back to div when componentName is not a valid HTML tag and no ref entry', async () => {
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({ primitives: {} }) as never,
+    );
+    const tag = await resolveHtmlTag('datepicker', ARK_REF_PATH);
+    expect(tag).toBe('div');
+  });
+
+  it('falls back to div when ark-ui-reference.json read fails', async () => {
+    mockReadFile.mockRejectedValueOnce(new Error('ENOENT') as never);
+    const tag = await resolveHtmlTag('datepicker', ARK_REF_PATH);
+    expect(tag).toBe('div');
+  });
+
+  it('falls back to div when ark-ui-reference.json contains invalid JSON', async () => {
+    mockReadFile.mockResolvedValueOnce('not valid json' as never);
+    const tag = await resolveHtmlTag('datepicker', ARK_REF_PATH);
+    expect(tag).toBe('div');
+  });
+});
+
+// ── introspectGoldenSample ────────────────────────────────────────────────────
+
+describe('introspectGoldenSample', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns slot and variant names when all files are present', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile.mockResolvedValueOnce(makeRecipeContent() as never);
+
+    const patterns = await introspectGoldenSample(WORKSPACE);
+
+    expect(patterns.slots).toEqual(['root', 'label', 'icon', 'spinner']);
+    expect(patterns.variants).toEqual(['solid', 'outline', 'ghost']);
+  });
+
+  it('throws REJECTED: golden sample incomplete when a file is missing', async () => {
+    mockAccess.mockRejectedValueOnce(new Error('ENOENT') as never);
+
+    await expect(introspectGoldenSample(WORKSPACE)).rejects.toThrow(
+      'REJECTED: golden sample incomplete',
+    );
+  });
+
+  it('uses default slots when recipe has no slots array', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile.mockResolvedValueOnce(
+      'export const r = createSlotRecipe({});' as never,
+    );
+
+    const patterns = await introspectGoldenSample(WORKSPACE);
+    expect(patterns.slots).toEqual(['root', 'label']);
+  });
+
+  it('uses default variants when recipe has no variant block', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile.mockResolvedValueOnce(
+      "import { createSlotRecipe } from '@isolate-ui/utils';\nexport const r = createSlotRecipe({ slots: ['root'] });" as never,
+    );
+
+    const patterns = await introspectGoldenSample(WORKSPACE);
+    expect(patterns.variants).toEqual(['solid', 'outline', 'ghost']);
+  });
+});
+
+// ── runNxGenerator ────────────────────────────────────────────────────────────
+
+describe('runNxGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls execFileAsync with the correct mandatory flags', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: 'ok', stderr: '' } as never);
+
+    await runNxGenerator(WORKSPACE, 'checkbox');
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'pnpm',
+      expect.arrayContaining([
+        '--publishable',
+        '--importPath=@isolate-ui/checkbox',
+        '--directory=libs/react/checkbox',
+      ]),
+      expect.objectContaining({ cwd: WORKSPACE }),
+    );
+  });
+
+  it('rejects when execFile rejects', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('generator failed') as never);
+    await expect(runNxGenerator(WORKSPACE, 'checkbox')).rejects.toThrow(
+      'generator failed',
+    );
+  });
+});
+
+// ── writeComponentFile ────────────────────────────────────────────────────────
+
+describe('writeComponentFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes a file containing HTMLArkProps and ark.<tagName>', async () => {
+    await writeComponentFile('/dir', 'checkbox', 'input', ['root', 'label']);
+
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain("HTMLArkProps<'input'>");
+    expect(content).toContain('ark.input');
+  });
+
+  it('uses PascalCase for the component name', async () => {
+    await writeComponentFile('/dir', 'my-component', 'div', ['root']);
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('MyComponent');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('EACCES') as never);
+    await expect(
+      writeComponentFile('/dir', 'checkbox', 'input', ['root']),
+    ).rejects.toThrow('EACCES');
+  });
+});
+
+// ── writeRecipeFile ───────────────────────────────────────────────────────────
+
+describe('writeRecipeFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes a file importing createSlotRecipe with the given slots and variants', async () => {
+    await writeRecipeFile(
+      '/dir',
+      'checkbox',
+      ['root', 'label'],
+      ['solid', 'outline'],
+    );
+
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain("from '@isolate-ui/utils'");
+    expect(content).toContain("'root', 'label'");
+    expect(content).toContain('solid');
+    expect(content).toContain('outline');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('disk full') as never);
+    await expect(
+      writeRecipeFile('/dir', 'checkbox', ['root'], ['solid']),
+    ).rejects.toThrow('disk full');
+  });
+});
+
+// ── writeStoriesFile ──────────────────────────────────────────────────────────
+
+describe('writeStoriesFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes Default and AllVariants CSF 3.0 stories', async () => {
+    await writeStoriesFile('/dir', 'checkbox', ['solid', 'outline']);
+
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('export const Default');
+    expect(content).toContain('export const AllVariants');
+    expect(content).toContain('variant="solid"');
+    expect(content).toContain('variant="outline"');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('EACCES') as never);
+    await expect(
+      writeStoriesFile('/dir', 'checkbox', ['solid']),
+    ).rejects.toThrow('EACCES');
+  });
+});
+
+// ── writeComponentTestFile ────────────────────────────────────────────────────
+
+describe('writeComponentTestFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteFile.mockResolvedValue(undefined as never);
+  });
+
+  it('writes a CT test importing from @isolate-ui/utils/a11y', async () => {
+    await writeComponentTestFile('/dir', 'checkbox');
+
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(content).toContain('@isolate-ui/utils/a11y');
+    expect(content).toContain('expectToHaveNoA11yViolations');
+  });
+
+  it('rejects when writeFile rejects', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('ENOENT') as never);
+    await expect(writeComponentTestFile('/dir', 'checkbox')).rejects.toThrow(
+      'ENOENT',
+    );
+  });
+});
+
+// ── runBuildAndTest ───────────────────────────────────────────────────────────
+
+describe('runBuildAndTest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns success: true when both build and test pass', async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never);
+
+    const result = await runBuildAndTest(WORKSPACE, 'checkbox');
+    expect(result.success).toBe(true);
+    expect(result.errorLog).toBe('');
+  });
+
+  it('returns success: false with errorLog when build fails', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('build error') as never);
+
+    const result = await runBuildAndTest(WORKSPACE, 'checkbox');
+    expect(result.success).toBe(false);
+    expect(result.errorLog).toContain('build error');
+  });
+
+  it('returns success: false with errorLog when test fails', async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never)
+      .mockRejectedValueOnce(new Error('test failure') as never);
+
+    const result = await runBuildAndTest(WORKSPACE, 'checkbox');
+    expect(result.success).toBe(false);
+    expect(result.errorLog).toContain('test failure');
+  });
+});
+
+// ── attemptAutoFix ────────────────────────────────────────────────────────────
+
+describe('attemptAutoFix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns success: true when panda codegen succeeds', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' } as never);
+
+    const result = await attemptAutoFix(WORKSPACE, 'checkbox', 'some error');
+    expect(result.success).toBe(true);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'pnpm',
+      ['exec', 'panda', 'codegen'],
+      expect.objectContaining({ cwd: WORKSPACE }),
+    );
+  });
+
+  it('returns success: false when panda codegen fails', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('codegen failed') as never);
+
+    const result = await attemptAutoFix(WORKSPACE, 'checkbox', 'build error');
+    expect(result.success).toBe(false);
+    expect(result.errorLog).toContain('codegen failed');
+  });
+});
+
+// ── createDevBoilerplateNode ──────────────────────────────────────────────────
+
+describe('createDevBoilerplateNode', () => {
+  const config = { workspaceRoot: WORKSPACE };
+
+  function setupHappyPath() {
+    // introspectGoldenSample: all files accessible + recipe readable
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never) // recipe (introspect)
+      .mockResolvedValueOnce(makeArkRef() as never); // ark-ui-reference.json (resolveHtmlTag)
+    // runNxGenerator + build + test
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx build
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never); // nx test
+    // writeFile calls
+    mockWriteFile.mockResolvedValue(undefined as never);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('happy path: returns APPROVED message and sets code_buffer', async () => {
+    setupHappyPath();
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/APPROVED/);
+    expect(result.code_buffer).toBeTruthy();
+  });
+
+  it('build fails, auto-fix succeeds: returns APPROVED after retry', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockWriteFile.mockResolvedValue(undefined as never);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockRejectedValueOnce(new Error('build fail') as never) // nx build (first attempt)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // panda codegen (auto-fix)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx build (retry)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never); // nx test (retry)
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/APPROVED/);
+  });
+
+  it('build fails, auto-fix also fails: escalates to human_review', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockWriteFile.mockResolvedValue(undefined as never);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockRejectedValueOnce(new Error('build fail') as never) // nx build
+      .mockRejectedValueOnce(new Error('panda fail') as never); // panda codegen
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    expect(result.next_recipient).toBe('human_review');
+    expect(result.pause_context).toBe('mesh_stalemate');
+    expect(result.mesh_origin).toBe('dev');
+  });
+
+  it('build fails, auto-fix runs but retry build also fails: escalates to human_review', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockWriteFile.mockResolvedValue(undefined as never);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // nx generate
+      .mockRejectedValueOnce(new Error('build fail') as never) // nx build (first)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as never) // panda codegen
+      .mockRejectedValueOnce(new Error('retry fail') as never); // nx build (retry)
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    expect(result.next_recipient).toBe('human_review');
+    expect(result.pause_context).toBe('mesh_stalemate');
+  });
+
+  it('missing component_name: returns REJECTED message', async () => {
+    const node = createDevBoilerplateNode(config);
+    const state = { ...createDefaultAgentState(), metadata: {} };
+    const result = await node(state);
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED: missing component_name/);
+    expect(result.next_recipient).toBeUndefined();
+  });
+
+  it('golden sample missing a file: returns REJECTED message', async () => {
+    mockAccess.mockRejectedValueOnce(new Error('ENOENT') as never);
+    mockReadFile.mockResolvedValueOnce(makeArkRef() as never);
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED: golden sample incomplete/);
+  });
+
+  it('Nx generator throws: returns REJECTED message', async () => {
+    mockAccess.mockResolvedValue(undefined as never);
+    mockReadFile
+      .mockResolvedValueOnce(makeRecipeContent() as never)
+      .mockResolvedValueOnce(makeArkRef() as never);
+    mockExecFile.mockRejectedValueOnce(new Error('nx error') as never);
+
+    const node = createDevBoilerplateNode(config);
+    const result = await node(makeState());
+
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toMatch(/REJECTED:/);
+    expect(lastMessage?.content).toContain('nx error');
+  });
+
+  it('does not mutate state directly', async () => {
+    setupHappyPath();
+
+    const node = createDevBoilerplateNode(config);
+    const state = makeState();
+    const originalMessages = state.messages;
+
+    await node(state);
+
+    // state.messages should be unchanged (node returns new array)
+    expect(state.messages).toBe(originalMessages);
+  });
+});

--- a/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/dev-node.spec.ts
@@ -515,7 +515,7 @@ describe('createDevBoilerplateNode', () => {
     expect(lastMessage?.content).toMatch(/APPROVED/);
   });
 
-  it('build fails, auto-fix also fails: escalates to human_review', async () => {
+  it('build fails, auto-fix also fails: escalates to human_review with both error logs', async () => {
     mockAccess.mockResolvedValue(undefined as never);
     mockReadFile
       .mockResolvedValueOnce(makeRecipeContent() as never)
@@ -532,6 +532,10 @@ describe('createDevBoilerplateNode', () => {
     expect(result.next_recipient).toBe('human_review');
     expect(result.pause_context).toBe('mesh_stalemate');
     expect(result.mesh_origin).toBe('dev');
+    // Escalation message must include both the original build error and the codegen error.
+    const lastMessage = result.messages?.[result.messages.length - 1];
+    expect(lastMessage?.content).toContain('build fail');
+    expect(lastMessage?.content).toContain('panda fail');
   });
 
   it('build fails, auto-fix runs but retry build also fails: escalates to human_review', async () => {

--- a/libs/ai-orchestrator/src/orchestrator/dev-node.ts
+++ b/libs/ai-orchestrator/src/orchestrator/dev-node.ts
@@ -666,8 +666,12 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
       return escalate(componentName, retryResult.errorLog);
     }
 
-    // 7. Escalate: auto-fix itself failed
-    return escalate(componentName, buildResult.errorLog);
+    // 7. Escalate: auto-fix itself failed — include both the build error and
+    // the codegen failure so human_review has the full picture.
+    const combinedLog =
+      `Build error:\n${buildResult.errorLog}\n\n` +
+      `Auto-fix (panda codegen) error:\n${fixResult.errorLog}`;
+    return escalate(componentName, combinedLog);
   };
 }
 

--- a/libs/ai-orchestrator/src/orchestrator/dev-node.ts
+++ b/libs/ai-orchestrator/src/orchestrator/dev-node.ts
@@ -1,0 +1,653 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { AgentState, SerializedMessage } from '../schema';
+import type { AgentNodeFn } from './langgraph';
+
+const execFileAsync = promisify(execFile);
+
+// ── Public Types ──────────────────────────────────────────────────────────────
+
+export interface DevNodeConfig {
+  workspaceRoot: string;
+  /** Override the golden sample directory (defaults to libs/react/button/src/lib). */
+  goldenSamplePath?: string;
+}
+
+export interface GoldenSamplePatterns {
+  slots: string[];
+  variants: string[];
+}
+
+// ── HTML Tag Resolution ───────────────────────────────────────────────────────
+
+const VALID_HTML_TAGS = new Set([
+  'a',
+  'abbr',
+  'address',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'blockquote',
+  'button',
+  'canvas',
+  'caption',
+  'cite',
+  'code',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dialog',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'embed',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hr',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'main',
+  'map',
+  'mark',
+  'menu',
+  'meter',
+  'nav',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'picture',
+  'pre',
+  'progress',
+  'q',
+  'section',
+  'select',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'tr',
+  'ul',
+  'var',
+  'video',
+]);
+
+interface ArkRefEntry {
+  htmlTag?: string;
+}
+
+interface ArkRef {
+  primitives?: Record<string, ArkRefEntry>;
+}
+
+/**
+ * Resolve the HTML element tag for `HTMLArkProps<T>` and `ark.<tag>`.
+ *
+ * Lookup order:
+ * 1. docs/ark-ui-reference.json `htmlTag` field for the matching component entry
+ * 2. componentName is itself a valid HTML element tag
+ * 3. Fall back to 'div'
+ */
+export async function resolveHtmlTag(
+  componentName: string,
+  arkRefPath: string,
+): Promise<string> {
+  try {
+    const raw = await fs.readFile(arkRefPath, 'utf-8');
+    const ref = JSON.parse(raw) as ArkRef;
+    const entry = ref.primitives?.[componentName.toLowerCase()];
+    if (entry?.htmlTag) {
+      return entry.htmlTag;
+    }
+  } catch {
+    // File unreadable or JSON parse failure — fall through to next strategy.
+  }
+
+  if (VALID_HTML_TAGS.has(componentName.toLowerCase())) {
+    return componentName.toLowerCase();
+  }
+
+  return 'div';
+}
+
+// ── Golden Sample Introspection ───────────────────────────────────────────────
+
+/**
+ * Validates that all four required golden sample files exist, then reads them
+ * to extract slot names and recipe variant names.
+ *
+ * Throws with message 'REJECTED: golden sample incomplete' if any file is absent.
+ */
+export async function introspectGoldenSample(
+  workspaceRoot: string,
+  goldenSamplePath?: string,
+): Promise<GoldenSamplePatterns> {
+  const libBase =
+    goldenSamplePath ??
+    path.join(workspaceRoot, 'libs', 'react', 'button', 'src', 'lib');
+  const projectJson = path.join(
+    workspaceRoot,
+    'libs',
+    'react',
+    'button',
+    'project.json',
+  );
+
+  const requiredFiles = [
+    path.join(libBase, 'button.tsx'),
+    path.join(libBase, 'button.recipe.ts'),
+    path.join(libBase, 'button.ct.tsx'),
+    projectJson,
+  ];
+
+  for (const file of requiredFiles) {
+    try {
+      await fs.access(file);
+    } catch {
+      throw new Error('REJECTED: golden sample incomplete');
+    }
+  }
+
+  const recipeContent = await fs.readFile(
+    path.join(libBase, 'button.recipe.ts'),
+    'utf-8',
+  );
+
+  // Extract slot names: slots: ['root', 'label', ...]
+  const slotsMatch = recipeContent.match(/slots:\s*\[([^\]]+)\]/);
+  const slots = slotsMatch
+    ? slotsMatch[1]
+        .split(',')
+        .map((s) => s.trim().replace(/['"]/g, ''))
+        .filter(Boolean)
+    : ['root', 'label'];
+
+  // Extract variant names from the variants.variant block (6-space indented keys)
+  const variantMatches = [...recipeContent.matchAll(/^ {6}(\w+):\s*\{/gm)];
+  const variants =
+    variantMatches.length > 0
+      ? variantMatches.map((m) => m[1])
+      : ['solid', 'outline', 'ghost'];
+
+  return { slots, variants };
+}
+
+// ── Nx Generator ─────────────────────────────────────────────────────────────
+
+/**
+ * Runs `pnpm nx generate @nx/react:lib` for a new component library.
+ * --publishable and --importPath are mandatory to match monorepo conventions.
+ */
+export async function runNxGenerator(
+  workspaceRoot: string,
+  componentName: string,
+): Promise<{ stdout: string; stderr: string }> {
+  const { stdout, stderr } = await execFileAsync(
+    'pnpm',
+    [
+      'nx',
+      'generate',
+      '@nx/react:lib',
+      componentName,
+      `--directory=libs/react/${componentName}`,
+      '--unitTestRunner=vitest',
+      '--bundler=vite',
+      '--linter=eslint',
+      '--publishable',
+      `--importPath=@isolate-ui/${componentName}`,
+    ],
+    { cwd: workspaceRoot },
+  );
+  return { stdout, stderr };
+}
+
+// ── File Writers ──────────────────────────────────────────────────────────────
+
+/**
+ * Writes the main component TSX file using HTMLArkProps and ark.<tagName>.
+ */
+export async function writeComponentFile(
+  dir: string,
+  componentName: string,
+  tagName: string,
+  slots: string[],
+): Promise<void> {
+  const pascal = toPascal(componentName);
+  void slots; // slots inform recipe structure; component renders root + label
+
+  const content = [
+    `import type { HTMLArkProps } from '@ark-ui/react';`,
+    `import { ark } from '@ark-ui/react';`,
+    `import { cx } from 'styled-system/css';`,
+    `import { ${componentName}Recipe, type ${pascal}RecipeVariants } from './${componentName}.recipe';`,
+    ``,
+    `export type ${pascal}Props = HTMLArkProps<'${tagName}'> & {`,
+    `  /** Visual style variant. */`,
+    `  variant?: ${pascal}RecipeVariants['variant'];`,
+    `};`,
+    ``,
+    `export function ${pascal}({`,
+    `  children,`,
+    `  className,`,
+    `  variant,`,
+    `  ...props`,
+    `}: ${pascal}Props) {`,
+    `  const styles = ${componentName}Recipe({ variant });`,
+    ``,
+    `  return (`,
+    `    <ark.${tagName}`,
+    `      {...props}`,
+    `      className={cx(styles.root, className)}`,
+    `    >`,
+    `      <span className={styles.label}>{children}</span>`,
+    `    </ark.${tagName}>`,
+    `  );`,
+    `}`,
+    ``,
+    `export default ${pascal};`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(path.join(dir, `${componentName}.tsx`), content, 'utf-8');
+}
+
+/**
+ * Writes the Panda CSS slot recipe file using createSlotRecipe from @isolate-ui/utils.
+ */
+export async function writeRecipeFile(
+  dir: string,
+  componentName: string,
+  slots: string[],
+  variants: string[],
+): Promise<void> {
+  const pascal = toPascal(componentName);
+  const slotsArray = slots.map((s) => `'${s}'`).join(', ');
+  const defaultVariant = variants[0] ?? 'default';
+
+  const variantEntries = variants
+    .map((v) => `      ${v}: {\n        root: {},\n      },`)
+    .join('\n');
+
+  const content = [
+    `import { createSlotRecipe } from '@isolate-ui/utils';`,
+    ``,
+    `export const ${componentName}Recipe = createSlotRecipe({`,
+    `  className: '${componentName}',`,
+    `  slots: [${slotsArray}],`,
+    `  base: {`,
+    `    root: {`,
+    `      display: 'inline-flex',`,
+    `      alignItems: 'center',`,
+    `    },`,
+    `    label: {`,
+    `      lineHeight: 'normal',`,
+    `    },`,
+    `  },`,
+    `  variants: {`,
+    `    variant: {`,
+    variantEntries,
+    `    },`,
+    `  },`,
+    `  defaultVariants: {`,
+    `    variant: '${defaultVariant}',`,
+    `  },`,
+    `});`,
+    ``,
+    `export type ${pascal}RecipeVariants = NonNullable<`,
+    `  Parameters<typeof ${componentName}Recipe>[0]`,
+    `>;`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(
+    path.join(dir, `${componentName}.recipe.ts`),
+    content,
+    'utf-8',
+  );
+}
+
+/**
+ * Writes a CSF 3.0 Storybook stories file with Default and AllVariants stories.
+ * AllVariants is a static render templated from the variants array — no dynamic import.
+ */
+export async function writeStoriesFile(
+  dir: string,
+  componentName: string,
+  variants: string[],
+): Promise<void> {
+  const pascal = toPascal(componentName);
+
+  const allVariantsJsx = variants
+    .map((v) => `      <${pascal} variant="${v}">${pascal} ${v}</${pascal}>`)
+    .join('\n');
+
+  const content = [
+    `import type { Meta, StoryObj } from '@storybook/react';`,
+    `import { ${pascal} } from './${componentName}';`,
+    ``,
+    `const meta: Meta<typeof ${pascal}> = {`,
+    `  title: 'React/${pascal}',`,
+    `  component: ${pascal},`,
+    `  tags: ['autodocs'],`,
+    `  parameters: {`,
+    `    layout: 'centered',`,
+    `  },`,
+    `};`,
+    ``,
+    `export default meta;`,
+    `type Story = StoryObj<typeof meta>;`,
+    ``,
+    `export const Default: Story = {`,
+    `  args: {`,
+    `    children: '${pascal}',`,
+    `  },`,
+    `};`,
+    ``,
+    `export const AllVariants: Story = {`,
+    `  render: () => (`,
+    `    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>`,
+    allVariantsJsx,
+    `    </div>`,
+    `  ),`,
+    `};`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(
+    path.join(dir, `${componentName}.stories.tsx`),
+    content,
+    'utf-8',
+  );
+}
+
+/**
+ * Writes a Playwright CT test file mirroring the golden sample pattern.
+ */
+export async function writeComponentTestFile(
+  dir: string,
+  componentName: string,
+): Promise<void> {
+  const pascal = toPascal(componentName);
+
+  const content = [
+    `import { expect, test } from '@playwright/experimental-ct-react';`,
+    `import { expectToHaveNoA11yViolations } from '@isolate-ui/utils/a11y';`,
+    `import ${pascal} from './${componentName}';`,
+    ``,
+    `test('renders and is visible', async ({ mount }) => {`,
+    `  const component = await mount(<${pascal}>${pascal}</${pascal}>);`,
+    `  await expect(component).toBeVisible();`,
+    `});`,
+    ``,
+    `test('passes a11y in default state', async ({ mount }) => {`,
+    `  const component = await mount(<${pascal}>${pascal}</${pascal}>);`,
+    `  await expectToHaveNoA11yViolations(component);`,
+    `});`,
+    ``,
+  ].join('\n');
+
+  await fs.writeFile(
+    path.join(dir, `${componentName}.ct.tsx`),
+    content,
+    'utf-8',
+  );
+}
+
+// ── Build & Test ──────────────────────────────────────────────────────────────
+
+/**
+ * Runs `pnpm nx build` then `pnpm nx test` for the generated component.
+ */
+export async function runBuildAndTest(
+  workspaceRoot: string,
+  componentName: string,
+): Promise<{ success: boolean; errorLog: string }> {
+  const projectName = `react-${componentName}`;
+  try {
+    await execFileAsync('pnpm', ['nx', 'build', projectName], {
+      cwd: workspaceRoot,
+    });
+    await execFileAsync('pnpm', ['nx', 'test', projectName, '--', '--run'], {
+      cwd: workspaceRoot,
+    });
+    return { success: true, errorLog: '' };
+  } catch (err) {
+    const errorLog = err instanceof Error ? err.message : String(err);
+    return { success: false, errorLog };
+  }
+}
+
+/**
+ * Infrastructure-only auto-fix: re-runs Panda CSS codegen to refresh styled-system/.
+ * Does NOT patch generated source files.
+ */
+export async function attemptAutoFix(
+  workspaceRoot: string,
+  _componentName: string,
+  _errorLog: string,
+): Promise<{ success: boolean; errorLog: string }> {
+  try {
+    await execFileAsync('pnpm', ['exec', 'panda', 'codegen'], {
+      cwd: workspaceRoot,
+    });
+    return { success: true, errorLog: '' };
+  } catch (err) {
+    const errorLog = err instanceof Error ? err.message : String(err);
+    return { success: false, errorLog };
+  }
+}
+
+// ── Main Node Factory ─────────────────────────────────────────────────────────
+
+/**
+ * Creates the dev persona node function for component boilerplate generation.
+ *
+ * Flow:
+ * 1. Validate component_name in metadata — REJECTED if missing
+ * 2. Introspect golden sample — REJECTED if files absent
+ * 3. Resolve HTML tag via ark-ui-reference.json
+ * 4. Run Nx generator
+ * 5. Write component, recipe, stories, and CT test files
+ * 6. Run build + test — APPROVED if successful
+ * 7. Attempt Panda codegen auto-fix — APPROVED if subsequent build passes
+ * 8. Escalate to human_review with pause_context: 'mesh_stalemate' if auto-fix fails
+ */
+export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
+  return async (state: AgentState): Promise<Partial<AgentState>> => {
+    const componentName = state.metadata?.['component_name'] as
+      | string
+      | undefined;
+
+    if (!componentName) {
+      return {
+        messages: [
+          ...state.messages,
+          makeMessage(
+            'Component generation skipped: no component_name in metadata.\n\nREJECTED: missing component_name',
+          ),
+        ],
+      };
+    }
+
+    const slots = state.parts.length > 0 ? state.parts : ['root', 'label'];
+
+    // 1. Validate golden sample
+    let patterns: GoldenSamplePatterns;
+    try {
+      patterns = await introspectGoldenSample(
+        config.workspaceRoot,
+        config.goldenSamplePath,
+      );
+    } catch (err) {
+      const reason =
+        err instanceof Error ? err.message : 'golden sample incomplete';
+      const message = reason.startsWith('REJECTED:')
+        ? reason
+        : `REJECTED: ${reason}`;
+      return {
+        messages: [...state.messages, makeMessage(message)],
+      };
+    }
+
+    const { variants } = patterns;
+
+    // 2. Resolve HTML tag
+    const arkRefPath = path.join(
+      config.workspaceRoot,
+      'docs',
+      'ark-ui-reference.json',
+    );
+    const tagName = await resolveHtmlTag(componentName, arkRefPath);
+
+    // 3. Run Nx generator
+    try {
+      await runNxGenerator(config.workspaceRoot, componentName);
+    } catch (err) {
+      const errorLog = err instanceof Error ? err.message : String(err);
+      return {
+        messages: [
+          ...state.messages,
+          makeMessage(`Nx generator failed.\n\nREJECTED: ${errorLog}`),
+        ],
+      };
+    }
+
+    // 4. Write boilerplate files
+    const dir = path.join(
+      config.workspaceRoot,
+      'libs',
+      'react',
+      componentName,
+      'src',
+      'lib',
+    );
+    try {
+      await writeComponentFile(dir, componentName, tagName, slots);
+      await writeRecipeFile(dir, componentName, slots, variants);
+      await writeStoriesFile(dir, componentName, variants);
+      await writeComponentTestFile(dir, componentName);
+    } catch (err) {
+      const errorLog = err instanceof Error ? err.message : String(err);
+      return {
+        messages: [
+          ...state.messages,
+          makeMessage(`File write failed.\n\nREJECTED: ${errorLog}`),
+        ],
+      };
+    }
+
+    // 5. Build + test
+    const buildResult = await runBuildAndTest(
+      config.workspaceRoot,
+      componentName,
+    );
+    if (buildResult.success) {
+      return {
+        code_buffer: dir,
+        messages: [
+          ...state.messages,
+          makeMessage(
+            `Component \`${componentName}\` generated and verified.\n\nAPPROVED`,
+          ),
+        ],
+      };
+    }
+
+    // 6. Auto-fix (Panda codegen only)
+    const fixResult = await attemptAutoFix(
+      config.workspaceRoot,
+      componentName,
+      buildResult.errorLog,
+    );
+    if (fixResult.success) {
+      const retryResult = await runBuildAndTest(
+        config.workspaceRoot,
+        componentName,
+      );
+      if (retryResult.success) {
+        return {
+          code_buffer: dir,
+          messages: [
+            ...state.messages,
+            makeMessage(
+              `Component \`${componentName}\` generated and verified after auto-fix.\n\nAPPROVED`,
+            ),
+          ],
+        };
+      }
+      // Auto-fix ran but retry still failed — use retry's error log for escalation
+      return escalate(state, componentName, retryResult.errorLog);
+    }
+
+    // 7. Escalate: auto-fix itself failed
+    return escalate(state, componentName, buildResult.errorLog);
+  };
+}
+
+// ── Private Helpers ───────────────────────────────────────────────────────────
+
+function escalate(
+  state: AgentState,
+  componentName: string,
+  errorLog: string,
+): Partial<AgentState> {
+  return {
+    next_recipient: 'human_review',
+    pause_context: 'mesh_stalemate',
+    mesh_origin: 'dev',
+    messages: [
+      ...state.messages,
+      makeMessage(
+        `Component \`${componentName}\` generation failed after auto-fix attempt.\n\n` +
+          `Error:\n${errorLog}\n\n` +
+          `REJECTED: auto-fix failed`,
+      ),
+    ],
+  };
+}
+
+function toPascal(name: string): string {
+  return name
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function makeMessage(content: string): SerializedMessage {
+  return { type: 'ai', content };
+}

--- a/libs/ai-orchestrator/src/orchestrator/dev-node.ts
+++ b/libs/ai-orchestrator/src/orchestrator/dev-node.ts
@@ -132,7 +132,11 @@ export async function resolveHtmlTag(
     const ref = JSON.parse(raw) as ArkRef;
     const entry = ref.primitives?.[componentName.toLowerCase()];
     if (entry?.htmlTag) {
-      return entry.htmlTag;
+      const normalised = entry.htmlTag.toLowerCase();
+      if (VALID_HTML_TAGS.has(normalised)) {
+        return normalised;
+      }
+      // Invalid htmlTag value in JSON — fall through to next strategy.
     }
   } catch {
     // File unreadable or JSON parse failure — fall through to next strategy.
@@ -160,13 +164,9 @@ export async function introspectGoldenSample(
   const libBase =
     goldenSamplePath ??
     path.join(workspaceRoot, 'libs', 'react', 'button', 'src', 'lib');
-  const projectJson = path.join(
-    workspaceRoot,
-    'libs',
-    'react',
-    'button',
-    'project.json',
-  );
+  // Derive projectJson relative to libBase (which is at src/lib level).
+  // This correctly handles both the default button path and any goldenSamplePath override.
+  const projectJson = path.join(libBase, '..', '..', 'project.json');
 
   const requiredFiles = [
     path.join(libBase, 'button.tsx'),
@@ -245,10 +245,10 @@ export async function writeComponentFile(
   dir: string,
   componentName: string,
   tagName: string,
-  slots: string[],
+  _slots: string[],
 ): Promise<void> {
   const pascal = toPascal(componentName);
-  void slots; // slots inform recipe structure; component renders root + label
+  // 'root' and 'label' are always normalized into slots by createDevBoilerplateNode.
 
   const content = [
     `import type { HTMLArkProps } from '@ark-ui/react';`,
@@ -299,8 +299,23 @@ export async function writeRecipeFile(
   const slotsArray = slots.map((s) => `'${s}'`).join(', ');
   const defaultVariant = variants[0] ?? 'default';
 
+  const baseEntries = slots
+    .map((slot) => {
+      if (slot === 'root') {
+        return `    root: {\n      display: 'inline-flex',\n      alignItems: 'center',\n    },`;
+      }
+      if (slot === 'label') {
+        return `    label: {\n      lineHeight: 'normal',\n    },`;
+      }
+      return `    ${slot}: {},`;
+    })
+    .join('\n');
+
   const variantEntries = variants
-    .map((v) => `      ${v}: {\n        root: {},\n      },`)
+    .map((v) => {
+      const slotEntries = slots.map((s) => `        ${s}: {},`).join('\n');
+      return `      ${v}: {\n${slotEntries}\n      },`;
+    })
     .join('\n');
 
   const content = [
@@ -310,13 +325,7 @@ export async function writeRecipeFile(
     `  className: '${componentName}',`,
     `  slots: [${slotsArray}],`,
     `  base: {`,
-    `    root: {`,
-    `      display: 'inline-flex',`,
-    `      alignItems: 'center',`,
-    `    },`,
-    `    label: {`,
-    `      lineHeight: 'normal',`,
-    `    },`,
+    baseEntries,
     `  },`,
     `  variants: {`,
     `    variant: {`,
@@ -504,7 +513,19 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
       };
     }
 
-    const slots = state.parts.length > 0 ? state.parts : ['root', 'label'];
+    // Validate componentName to prevent path traversal from untrusted metadata.
+    const nameError = validateComponentName(
+      componentName,
+      config.workspaceRoot,
+    );
+    if (nameError) {
+      return {
+        messages: [...state.messages, makeMessage(nameError)],
+      };
+    }
+
+    // Normalize slots — root and label are always required by the component template.
+    const slots = Array.from(new Set(['root', 'label', ...state.parts]));
 
     // 1. Validate golden sample
     let patterns: GoldenSamplePatterns;
@@ -556,6 +577,21 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
       'src',
       'lib',
     );
+    // Build a reviewable text summary for downstream personas (a11y/qa/docs).
+    // code_buffer carries content that agents can inspect, not a filesystem path.
+    const codeBuffer = [
+      `Generated component: \`${componentName}\``,
+      ``,
+      `Files created:`,
+      `- libs/react/${componentName}/src/lib/${componentName}.tsx`,
+      `- libs/react/${componentName}/src/lib/${componentName}.recipe.ts`,
+      `- libs/react/${componentName}/src/lib/${componentName}.stories.tsx`,
+      `- libs/react/${componentName}/src/lib/${componentName}.ct.tsx`,
+      ``,
+      `Slots: ${slots.join(', ')}`,
+      `Variants: ${variants.join(', ')}`,
+      `HTML tag: ${tagName}`,
+    ].join('\n');
     try {
       await writeComponentFile(dir, componentName, tagName, slots);
       await writeRecipeFile(dir, componentName, slots, variants);
@@ -578,7 +614,7 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
     );
     if (buildResult.success) {
       return {
-        code_buffer: dir,
+        code_buffer: codeBuffer,
         messages: [
           ...state.messages,
           makeMessage(
@@ -601,7 +637,7 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
       );
       if (retryResult.success) {
         return {
-          code_buffer: dir,
+          code_buffer: codeBuffer,
           messages: [
             ...state.messages,
             makeMessage(
@@ -620,6 +656,33 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
 }
 
 // ── Private Helpers ───────────────────────────────────────────────────────────
+
+const COMPONENT_NAME_RE = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * Validates componentName to prevent path traversal from untrusted metadata.
+ * Returns an error string (starting with 'REJECTED:') if invalid, null if valid.
+ */
+function validateComponentName(
+  componentName: string,
+  workspaceRoot: string,
+): string | null {
+  if (!COMPONENT_NAME_RE.test(componentName)) {
+    return 'REJECTED: component_name must match ^[a-z][a-z0-9-]*$';
+  }
+  const resolvedDir = path.resolve(
+    workspaceRoot,
+    'libs',
+    'react',
+    componentName,
+  );
+  const expectedPrefix =
+    path.resolve(workspaceRoot, 'libs', 'react') + path.sep;
+  if (!resolvedDir.startsWith(expectedPrefix)) {
+    return 'REJECTED: component_name would resolve outside libs/react';
+  }
+  return null;
+}
 
 function escalate(
   state: AgentState,

--- a/libs/ai-orchestrator/src/orchestrator/dev-node.ts
+++ b/libs/ai-orchestrator/src/orchestrator/dev-node.ts
@@ -248,13 +248,14 @@ export async function writeComponentFile(
   _slots: string[],
 ): Promise<void> {
   const pascal = toPascal(componentName);
+  const camel = toCamel(componentName);
   // 'root' and 'label' are always normalized into slots by createDevBoilerplateNode.
 
   const content = [
     `import type { HTMLArkProps } from '@ark-ui/react';`,
     `import { ark } from '@ark-ui/react';`,
     `import { cx } from 'styled-system/css';`,
-    `import { ${componentName}Recipe, type ${pascal}RecipeVariants } from './${componentName}.recipe';`,
+    `import { ${camel}Recipe, type ${pascal}RecipeVariants } from './${componentName}.recipe';`,
     ``,
     `export type ${pascal}Props = HTMLArkProps<'${tagName}'> & {`,
     `  /** Visual style variant. */`,
@@ -267,7 +268,7 @@ export async function writeComponentFile(
     `  variant,`,
     `  ...props`,
     `}: ${pascal}Props) {`,
-    `  const styles = ${componentName}Recipe({ variant });`,
+    `  const styles = ${camel}Recipe({ variant });`,
     ``,
     `  return (`,
     `    <ark.${tagName}`,
@@ -296,6 +297,7 @@ export async function writeRecipeFile(
   variants: string[],
 ): Promise<void> {
   const pascal = toPascal(componentName);
+  const camel = toCamel(componentName);
   const slotsArray = slots.map((s) => `'${s}'`).join(', ');
   const defaultVariant = variants[0] ?? 'default';
 
@@ -321,7 +323,7 @@ export async function writeRecipeFile(
   const content = [
     `import { createSlotRecipe } from '@isolate-ui/utils';`,
     ``,
-    `export const ${componentName}Recipe = createSlotRecipe({`,
+    `export const ${camel}Recipe = createSlotRecipe({`,
     `  className: '${componentName}',`,
     `  slots: [${slotsArray}],`,
     `  base: {`,
@@ -338,7 +340,7 @@ export async function writeRecipeFile(
     `});`,
     ``,
     `export type ${pascal}RecipeVariants = NonNullable<`,
-    `  Parameters<typeof ${componentName}Recipe>[0]`,
+    `  Parameters<typeof ${camel}Recipe>[0]`,
     `>;`,
     ``,
   ].join('\n');
@@ -456,8 +458,11 @@ export async function runBuildAndTest(
     });
     return { success: true, errorLog: '' };
   } catch (err) {
-    const errorLog = err instanceof Error ? err.message : String(err);
-    return { success: false, errorLog };
+    const lines: string[] = [err instanceof Error ? err.message : String(err)];
+    const execErr = err as { stderr?: string; stdout?: string };
+    if (execErr.stderr) lines.push(`stderr:\n${execErr.stderr}`);
+    if (execErr.stdout) lines.push(`stdout:\n${execErr.stdout}`);
+    return { success: false, errorLog: lines.join('\n\n') };
   }
 }
 
@@ -476,8 +481,11 @@ export async function attemptAutoFix(
     });
     return { success: true, errorLog: '' };
   } catch (err) {
-    const errorLog = err instanceof Error ? err.message : String(err);
-    return { success: false, errorLog };
+    const lines: string[] = [err instanceof Error ? err.message : String(err)];
+    const execErr = err as { stderr?: string; stdout?: string };
+    if (execErr.stderr) lines.push(`stderr:\n${execErr.stderr}`);
+    if (execErr.stdout) lines.push(`stdout:\n${execErr.stdout}`);
+    return { success: false, errorLog: lines.join('\n\n') };
   }
 }
 
@@ -505,7 +513,6 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
     if (!componentName) {
       return {
         messages: [
-          ...state.messages,
           makeMessage(
             'Component generation skipped: no component_name in metadata.\n\nREJECTED: missing component_name',
           ),
@@ -520,12 +527,27 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
     );
     if (nameError) {
       return {
-        messages: [...state.messages, makeMessage(nameError)],
+        messages: [makeMessage(nameError)],
       };
     }
 
     // Normalize slots — root and label are always required by the component template.
     const slots = Array.from(new Set(['root', 'label', ...state.parts]));
+
+    // Validate that each slot name is a plain JS identifier (no hyphens or special chars).
+    // Slot names are used as unquoted object keys and dot-notation accessors in generated code.
+    const SLOT_NAME_RE = /^[a-z][a-z0-9]*$/;
+    const invalidSlot = slots.find((s) => !SLOT_NAME_RE.test(s));
+    if (invalidSlot) {
+      return {
+        messages: [
+          makeMessage(
+            `REJECTED: slot name '${invalidSlot}' is not a valid identifier. ` +
+              `Parts must match ^[a-z][a-z0-9]*$`,
+          ),
+        ],
+      };
+    }
 
     // 1. Validate golden sample
     let patterns: GoldenSamplePatterns;
@@ -541,7 +563,7 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
         ? reason
         : `REJECTED: ${reason}`;
       return {
-        messages: [...state.messages, makeMessage(message)],
+        messages: [makeMessage(message)],
       };
     }
 
@@ -562,7 +584,6 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
       const errorLog = err instanceof Error ? err.message : String(err);
       return {
         messages: [
-          ...state.messages,
           makeMessage(`Nx generator failed.\n\nREJECTED: ${errorLog}`),
         ],
       };
@@ -600,10 +621,7 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
     } catch (err) {
       const errorLog = err instanceof Error ? err.message : String(err);
       return {
-        messages: [
-          ...state.messages,
-          makeMessage(`File write failed.\n\nREJECTED: ${errorLog}`),
-        ],
+        messages: [makeMessage(`File write failed.\n\nREJECTED: ${errorLog}`)],
       };
     }
 
@@ -616,7 +634,6 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
       return {
         code_buffer: codeBuffer,
         messages: [
-          ...state.messages,
           makeMessage(
             `Component \`${componentName}\` generated and verified.\n\nAPPROVED`,
           ),
@@ -639,7 +656,6 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
         return {
           code_buffer: codeBuffer,
           messages: [
-            ...state.messages,
             makeMessage(
               `Component \`${componentName}\` generated and verified after auto-fix.\n\nAPPROVED`,
             ),
@@ -647,11 +663,11 @@ export function createDevBoilerplateNode(config: DevNodeConfig): AgentNodeFn {
         };
       }
       // Auto-fix ran but retry still failed — use retry's error log for escalation
-      return escalate(state, componentName, retryResult.errorLog);
+      return escalate(componentName, retryResult.errorLog);
     }
 
     // 7. Escalate: auto-fix itself failed
-    return escalate(state, componentName, buildResult.errorLog);
+    return escalate(componentName, buildResult.errorLog);
   };
 }
 
@@ -685,20 +701,22 @@ function validateComponentName(
 }
 
 function escalate(
-  state: AgentState,
   componentName: string,
   errorLog: string,
 ): Partial<AgentState> {
+  // Do NOT end with REJECTED/APPROVED — the refinement wrapper parses those
+  // markers and would override next_recipient. A neutral message lets the
+  // wrapper return PENDING and pass through the explicit next_recipient.
   return {
     next_recipient: 'human_review',
     pause_context: 'mesh_stalemate',
     mesh_origin: 'dev',
     messages: [
-      ...state.messages,
       makeMessage(
         `Component \`${componentName}\` generation failed after auto-fix attempt.\n\n` +
+          `Build errors could not be resolved automatically.\n\n` +
           `Error:\n${errorLog}\n\n` +
-          `REJECTED: auto-fix failed`,
+          `STALEMATE: escalating to human review`,
       ),
     ],
   };
@@ -709,6 +727,18 @@ function toPascal(name: string): string {
     .split(/[-_]/)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join('');
+}
+
+/** Returns a camelCase identifier from a kebab/snake-case component name. */
+function toCamel(name: string): string {
+  const parts = name.split(/[-_]/);
+  return (
+    (parts[0] ?? '') +
+    parts
+      .slice(1)
+      .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+      .join('')
+  );
 }
 
 function makeMessage(content: string): SerializedMessage {

--- a/libs/ai-orchestrator/src/orchestrator/index.ts
+++ b/libs/ai-orchestrator/src/orchestrator/index.ts
@@ -40,3 +40,19 @@ export {
   type ApplyCodeBufferSuccess,
   type ApplyCodeBufferFailure,
 } from './git-utils';
+
+// Dev boilerplate node
+export {
+  createDevBoilerplateNode,
+  introspectGoldenSample,
+  resolveHtmlTag,
+  runNxGenerator,
+  writeComponentFile,
+  writeRecipeFile,
+  writeStoriesFile,
+  writeComponentTestFile,
+  runBuildAndTest,
+  attemptAutoFix,
+  type DevNodeConfig,
+  type GoldenSamplePatterns,
+} from './dev-node';

--- a/libs/ai-orchestrator/src/orchestrator/langgraph.ts
+++ b/libs/ai-orchestrator/src/orchestrator/langgraph.ts
@@ -162,6 +162,10 @@ export class OrchestratorGraph {
           value: (x: any, y: any) => (y !== undefined ? y : x),
           default: () => null,
         },
+        parts: {
+          value: (x: any, y: any) => (y !== undefined ? y : x),
+          default: () => [],
+        },
       },
     });
 

--- a/libs/ai-orchestrator/src/schema/agent-state.ts
+++ b/libs/ai-orchestrator/src/schema/agent-state.ts
@@ -134,8 +134,8 @@ export const AgentStateSchema = z.object({
 
   /**
    * Component slot names to generate for the new component.
-   * Populated by the dev node from the incoming request or defaulted to
-   * ['root', 'label'] when absent. Used to drive recipe and boilerplate generation.
+   * Set by callers before invoking the dev node. When empty, the dev node
+   * falls back to ['root', 'label']. Used to drive recipe and boilerplate generation.
    */
   parts: z.array(z.string()).default(() => []),
 });

--- a/libs/ai-orchestrator/src/schema/agent-state.ts
+++ b/libs/ai-orchestrator/src/schema/agent-state.ts
@@ -131,6 +131,13 @@ export const AgentStateSchema = z.object({
     .enum(['refinement_limit', 'mesh_stalemate'])
     .nullable()
     .default(null),
+
+  /**
+   * Component slot names to generate for the new component.
+   * Populated by the dev node from the incoming request or defaulted to
+   * ['root', 'label'] when absent. Used to drive recipe and boilerplate generation.
+   */
+  parts: z.array(z.string()).default(() => []),
 });
 
 export type AgentState = z.infer<typeof AgentStateSchema>;
@@ -153,6 +160,7 @@ export const DEFAULT_AGENT_STATE: AgentState = {
   mesh_loop_count: 0,
   mesh_origin: null,
   pause_context: null,
+  parts: [],
 };
 
 /**
@@ -176,5 +184,6 @@ export function createDefaultAgentState(): AgentState {
     mesh_loop_count: 0,
     mesh_origin: null,
     pause_context: null,
+    parts: [],
   };
 }


### PR DESCRIPTION
## Summary

Implements the `dev` LangGraph node as a real component-generation node (Issue #22), replacing the no-op pass-through. The node introspects the button golden sample, runs `pnpm nx generate`, writes component boilerplate files, runs build + test, attempts a single Panda codegen auto-fix on failure, and escalates to `human_review` (`pause_context: 'mesh_stalemate'`) if auto-fix fails.

Also updates workflow process rules in `copilot-instructions.md` to require human sign-off and phase commits before proceeding.

## Changes

- `libs/ai-orchestrator/src/schema/agent-state.ts` — add `parts` field to `AgentStateSchema`, `DEFAULT_AGENT_STATE`, and `createDefaultAgentState()`
- `libs/ai-orchestrator/src/orchestrator/langgraph.ts` — add `parts` channel in `buildGraph()`
- `libs/ai-orchestrator/src/orchestrator/dev-node.ts` — new file: `resolveHtmlTag`, `introspectGoldenSample`, `runNxGenerator`, `writeComponentFile`, `writeRecipeFile`, `writeStoriesFile`, `writeComponentTestFile`, `runBuildAndTest`, `attemptAutoFix`, `createDevBoilerplateNode`
- `libs/ai-orchestrator/src/orchestrator/index.ts` — export all new symbols
- `libs/ai-orchestrator/src/__tests__/dev-node.spec.ts` — 33 new tests
- `docs/ark-ui-reference.json` — add `"htmlTag": "button"` to the `button` entry
- `.github/copilot-instructions.md` — add human sign-off and phase commit rules

## Copilot Review Triage

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.

## Deferred follow-ups

- Nit: `_errorLog` param in `attemptAutoFix` — intentional underscore; auto-fix runs panda codegen unconditionally regardless of error content. No code change required.