### PR TITLE
chore: add agent instructions, prettier hook, and create-component prompt

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,34 @@ Follow them precisely; do not silently deviate.
 
 ---
 
+## Project Orientation
+
+Nx monorepo for the Isolate UI component library. Package manager: **pnpm**. Testing: **Vitest** (unit) + **Playwright CT** (component a11y).
+
+**Key paths:**
+
+- `libs/react/*/` — React component libraries
+- `libs/shared/tokens/` — Design token pipeline (Style Dictionary v4)
+- `libs/utils/` — Shared utilities; `@isolate-ui/utils/ai` exports `checkTokenExists()`
+- `libs/ai-orchestrator/` — LangGraph multi-agent orchestrator
+- `apps/webhook-listener/` — Fastify server that receives GitHub webhooks
+
+**Essential commands:**
+
+```bash
+pnpm vitest run            # run all unit tests once
+nx run-many -t test lint typecheck  # full quality gate
+nx affected -t test --base=origin/main  # only changed projects
+nx test react-button       # single project
+```
+
+**Full development guide:** [AGENTS.md](../AGENTS.md)
+**Accessibility testing guide:** [A11Y_TESTING.md](../A11Y_TESTING.md)
+
+---
+
+---
+
 ## Async / Error Handling
 
 - **No fire-and-forget.** Every top-level async call site must either `await` the call inside a `try/catch`, or chain `.catch()` with a handler that logs and exits (or re-throws). This applies to: command handlers (`approve.ts`, `fix.ts`, `query.ts`), startup functions, and any background work initiated from a route handler.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,8 +31,6 @@ nx test react-button       # single project
 
 ---
 
----
-
 ## Async / Error Handling
 
 - **No fire-and-forget.** Every top-level async call site must either `await` the call inside a `try/catch`, or chain `.catch()` with a handler that logs and exits (or re-throws). This applies to: command handlers (`approve.ts`, `fix.ts`, `query.ts`), startup functions, and any background work initiated from a route handler.

--- a/.github/hooks/prettier-on-edit.json
+++ b/.github/hooks/prettier-on-edit.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "type": "command",
+        "command": "pnpm format:affected",
+        "timeout": 60
+      }
+    ]
+  }
+}

--- a/.github/prompts/create-component.prompt.md
+++ b/.github/prompts/create-component.prompt.md
@@ -2,7 +2,7 @@
 mode: agent
 description: >-
   Create a new React component in the Isolate UI library. Use when: scaffolding
-  a new component, adding a new UI primitive, creating a new react library.
+  a new component, adding a new UI primitive, creating a new React library.
 ---
 
 Create a new React component library in the Isolate UI monorepo.
@@ -45,8 +45,7 @@ Follow the Button component pattern in `libs/react/button/src/lib/`:
 
 ```typescript
 import { ark } from '@ark-ui/react';
-import { cx } from 'styled-system/css';
-import { sva } from 'styled-system/css';
+import { cx, sva } from 'styled-system/css';
 // Never use relative paths across project boundaries
 // ✅ import { checkTokenExists } from '@isolate-ui/utils/ai';
 // ❌ import { checkTokenExists } from '../../utils/src/lib/ai';

--- a/.github/prompts/create-component.prompt.md
+++ b/.github/prompts/create-component.prompt.md
@@ -1,0 +1,90 @@
+---
+mode: agent
+description: >-
+  Create a new React component in the Isolate UI library. Use when: scaffolding
+  a new component, adding a new UI primitive, creating a new react library.
+---
+
+Create a new React component library in the Isolate UI monorepo.
+
+## Component name
+
+$component_name
+
+## Steps
+
+### 1. Generate the Nx library
+
+```bash
+nx generate @nx/react:lib $component_name \
+  --directory=libs/react/$component_name \
+  --unitTestRunner=vitest \
+  --bundler=vite \
+  --linter=eslint \
+  --importPath=@isolate-ui/$component_name
+```
+
+If the generator fails with a vitest ESM error, run with `--unitTestRunner=none` first, then add vitest separately:
+
+```bash
+nx g @nx/vitest:configuration --project=react-$component_name --uiFramework=react
+```
+
+### 2. Component implementation
+
+Follow the Button component pattern in `libs/react/button/src/lib/`:
+
+- Use `ark` from `@ark-ui/react` for the root element to get polymorphism and ARIA support
+- Define a slot recipe in `$component_name.recipe.ts` using `sva()` from `styled-system/css`
+- Use design tokens from `@isolate-ui/tokens` — validate any token reference with `checkTokenExists()` from `@isolate-ui/utils/ai` before using it
+- Export `$ComponentNameProps` type that extends the appropriate HTML element attributes interface
+- Spread `...restProps` onto the underlying element
+- Default `type="button"` where applicable
+
+**Imports:**
+
+```typescript
+import { ark } from '@ark-ui/react';
+import { cx } from 'styled-system/css';
+import { sva } from 'styled-system/css';
+// Never use relative paths across project boundaries
+// ✅ import { checkTokenExists } from '@isolate-ui/utils/ai';
+// ❌ import { checkTokenExists } from '../../utils/src/lib/ai';
+```
+
+### 3. Tests (Vitest unit)
+
+Create `$component_name.spec.tsx` alongside the component file with:
+
+- Happy path: renders successfully, renders children, applies className
+- Error/edge paths: at least one test for each exported async function's rejection case
+- Do **not** make real network calls; mock external dependencies
+
+Run: `nx test react-$component_name`
+
+### 4. Accessibility tests (Playwright CT)
+
+Follow [A11Y_TESTING.md](../../A11Y_TESTING.md):
+
+- Create `$component_name.ct.tsx` using `@playwright/experimental-ct-react`
+- Test all variants and states (default, disabled, loading, etc.)
+- Use `expectToHaveNoA11yViolations` from `@isolate-ui/utils/a11y`
+- Fix any color contrast violations before committing — do not disable axe rules
+
+Run: `pnpm nx run react-$component_name:component-test`
+
+### 5. Update snapshots if needed
+
+After fixing a11y issues that change CSS classes:
+
+```bash
+pnpm nx test react-$component_name -- -u
+```
+
+### 6. Quality gate
+
+```bash
+nx run-many -t test lint typecheck --projects=react-$component_name
+```
+
+Fix all errors. When green, run `#pre-pr-review` before reporting completion.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ The most distinctive aspect of Isolate UI is its agentic development workflow. T
 
 ### Agent Personas
 
-| Persona | Role |
-|---|---|
-| `@isolate-po` | Selects Ark UI primitives, maps design tokens, and produces the initial component specification |
+| Persona              | Role                                                                                                                  |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `@isolate-po`        | Selects Ark UI primitives, maps design tokens, and produces the initial component specification                       |
 | `@isolate-architect` | Enforces Nx project boundary rules and validates permitted shared utility imports before greenlighting implementation |
-| `@isolate-dev` | Implements TypeScript/React components with Panda CSS, following "The Blueprint" component pattern |
-| `@isolate-a11y` | Audits WAI-ARIA compliance and keyboard navigation, validates WCAG 2.1 Level AA conformance |
-| `@isolate-qa` | Validates Vitest test coverage (minimum 80%), error state recovery, and edge case handling |
-| `@isolate-docs` | Generates Storybook CSF stories and README artifacts documenting all prop interfaces and variants |
+| `@isolate-dev`       | Implements TypeScript/React components with Panda CSS, following "The Blueprint" component pattern                    |
+| `@isolate-a11y`      | Audits WAI-ARIA compliance and keyboard navigation, validates WCAG 2.1 Level AA conformance                           |
+| `@isolate-qa`        | Validates Vitest test coverage (minimum 80%), error state recovery, and edge case handling                            |
+| `@isolate-docs`      | Generates Storybook CSF stories and README artifacts documenting all prop interfaces and variants                     |
 
 ### The Consensus Loop
 
@@ -150,23 +150,23 @@ libs/
 
 ## Technology Stack
 
-| Category | Technology |
-|---|---|
-| **Monorepo** | [Nx](https://nx.dev) 22.5.4 |
-| **Package Manager** | [pnpm](https://pnpm.io) 10.30.3 |
-| **Agent Orchestration** | [LangGraph.js](https://langchain-ai.github.io/langgraphjs/) |
-| **UI Framework** | React 19 |
-| **Language** | TypeScript 5.9 |
-| **Build Tool** | [Vite](https://vitejs.dev) 7.x |
-| **Testing** | [Vitest](https://vitest.dev) 3.2.4 |
-| **Browser Testing** | [Playwright](https://playwright.dev) 1.58.2 |
-| **Accessibility** | [@axe-core/playwright](https://github.com/dequelabs/axe-core-npm) 4.11.1 |
-| **Documentation** | [Storybook](https://storybook.js.org) 8.6.18 |
-| **Styling** | [Panda CSS](https://panda-css.com) |
-| **Releases** | [Nx Release](https://nx.dev/features/manage-releases) with version plans |
-| **Commit Linting** | [Commitlint](https://commitlint.js.org/) + [Husky](https://typicode.github.io/husky/) |
-| **Deployment** | [Vercel](https://vercel.com) (Storybook previews) |
-| **Registry** | [NPM](https://www.npmjs.com) with provenance attestations |
+| Category                | Technology                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| **Monorepo**            | [Nx](https://nx.dev) 22.5.4                                                           |
+| **Package Manager**     | [pnpm](https://pnpm.io) 10.30.3                                                       |
+| **Agent Orchestration** | [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)                           |
+| **UI Framework**        | React 19                                                                              |
+| **Language**            | TypeScript 5.9                                                                        |
+| **Build Tool**          | [Vite](https://vitejs.dev) 7.x                                                        |
+| **Testing**             | [Vitest](https://vitest.dev) 3.2.4                                                    |
+| **Browser Testing**     | [Playwright](https://playwright.dev) 1.58.2                                           |
+| **Accessibility**       | [@axe-core/playwright](https://github.com/dequelabs/axe-core-npm) 4.11.1              |
+| **Documentation**       | [Storybook](https://storybook.js.org) 8.6.18                                          |
+| **Styling**             | [Panda CSS](https://panda-css.com)                                                    |
+| **Releases**            | [Nx Release](https://nx.dev/features/manage-releases) with version plans              |
+| **Commit Linting**      | [Commitlint](https://commitlint.js.org/) + [Husky](https://typicode.github.io/husky/) |
+| **Deployment**          | [Vercel](https://vercel.com) (Storybook previews)                                     |
+| **Registry**            | [NPM](https://www.npmjs.com) with provenance attestations                             |
 
 ---
 
@@ -353,17 +353,17 @@ Distributed caching is configured with Vercel Remote Cache. Cacheable operations
 
 ### Key Files
 
-| File | Purpose |
-|---|---|
-| [AGENTS.md](./AGENTS.md) | Agentic workflow reference and troubleshooting |
-| [libs/ai-orchestrator/README.md](./libs/ai-orchestrator/README.md) | Full orchestrator API reference |
-| [nx.json](./nx.json) | Nx workspace configuration with release settings |
-| [tsconfig.base.json](./tsconfig.base.json) | TypeScript base configuration and path mappings |
-| [vitest.workspace.ts](./vitest.workspace.ts) | Vitest workspace configuration |
-| [commitlint.config.ts](./commitlint.config.ts) | Commit message linting rules |
-| [vercel.json](./vercel.json) | Vercel deployment configuration |
-| [.github/workflows/ci.yml](./.github/workflows/ci.yml) | CI verification workflow |
-| [.github/workflows/release.yml](./.github/workflows/release.yml) | Automated release workflow |
+| File                                                               | Purpose                                          |
+| ------------------------------------------------------------------ | ------------------------------------------------ |
+| [AGENTS.md](./AGENTS.md)                                           | Agentic workflow reference and troubleshooting   |
+| [libs/ai-orchestrator/README.md](./libs/ai-orchestrator/README.md) | Full orchestrator API reference                  |
+| [nx.json](./nx.json)                                               | Nx workspace configuration with release settings |
+| [tsconfig.base.json](./tsconfig.base.json)                         | TypeScript base configuration and path mappings  |
+| [vitest.workspace.ts](./vitest.workspace.ts)                       | Vitest workspace configuration                   |
+| [commitlint.config.ts](./commitlint.config.ts)                     | Commit message linting rules                     |
+| [vercel.json](./vercel.json)                                       | Vercel deployment configuration                  |
+| [.github/workflows/ci.yml](./.github/workflows/ci.yml)             | CI verification workflow                         |
+| [.github/workflows/release.yml](./.github/workflows/release.yml)   | Automated release workflow                       |
 
 ### Path Mappings
 

--- a/apps/webhook-listener/AGENTS.md
+++ b/apps/webhook-listener/AGENTS.md
@@ -1,0 +1,62 @@
+# Agent Notes — Webhook Listener
+
+## Project Commands
+
+```bash
+nx build webhook-listener                   # build
+nx lint webhook-listener                    # lint
+# No unit test target — use integration tests or run vitest manually in src/
+```
+
+## Critical Security Pipeline (enforce on every change)
+
+The route pipeline **must** follow this order — never process the body before verifying the signature:
+
+```
+1. Filter: check X-GitHub-Event header
+2. HMAC verification  →  401 on failure (verifyHmac in src/security/hmac.ts)
+3. Require X-GitHub-Delivery header  →  400 if absent
+4. Parse payload; skip non-'created' actions  →  200
+5. Deduplication: INSERT delivery ID  →  200 if already seen
+6. Authorization: check author_association ∈ AUTHORIZED_ASSOCIATIONS
+7. Dispatch to command handler (/approve, /fix, /query)
+8. Reply 200
+```
+
+`AUTHORIZED_ASSOCIATIONS` = `{ 'OWNER', 'MEMBER', 'COLLABORATOR' }` — always check before business logic.
+
+## Command Handlers
+
+All command handlers live in `src/commands/`:
+
+- `approve.ts` — resumes a paused LangGraph thread from checkpoint
+- `fix.ts` — triggers a fix cycle from the current code buffer
+- `query.ts` — starts a new orchestrator thread for a GitHub issue
+- `context.ts` — `CommandContext` type + `postErrorReply` helper
+
+Every command handler is an `async` function. Top-level call sites must either `await` inside `try/catch` or chain `.catch()`. Never fire-and-forget.
+
+## Environment Variables
+
+Validated at startup in `src/main.ts` with `process.exit(1)` if absent:
+
+- `GITHUB_TOKEN` — PAT with `repo` scope (required)
+- `WEBHOOK_SECRET` — HMAC signing secret (required for signature verification)
+- `HOST` — defaults to `0.0.0.0`
+- `PORT` — defaults to `8080`
+- `GITHUB_OWNER`, `GITHUB_REPO` — defaults to `SteveJRobertson/isolate-ui`
+- `DATABASE_PATH` — SQLite file path (optional; resolved in `src/db/schema.ts`)
+
+**Never log these values.** Use `postErrorReply` for user-facing error messages.
+
+## Key Files
+
+```
+src/
+├── main.ts              # Fastify startup; env validation; rawBody registration
+├── routes/webhook.ts    # POST /api/webhook — the only route
+├── security/hmac.ts     # verifyHmac() — must be called before body parsing
+├── commands/            # approve.ts, fix.ts, query.ts, context.ts
+├── db/schema.ts         # openDb() + resolveDbPath() + SQLite migrations
+└── sync/startup.ts      # runStartupSync() — replays missed commands on boot
+```

--- a/libs/ai-orchestrator/AGENTS.md
+++ b/libs/ai-orchestrator/AGENTS.md
@@ -1,0 +1,67 @@
+# Agent Notes — AI Orchestrator
+
+See the full architecture overview in [README.md](README.md).
+
+## Project Commands
+
+```bash
+nx test ai-orchestrator        # run unit tests
+nx typecheck ai-orchestrator   # type check
+nx lint ai-orchestrator        # lint
+nx build ai-orchestrator       # build
+```
+
+## Key Constraints (enforce on every change)
+
+### LangGraph node functions
+
+- **Return `Partial<AgentState>` with only changed fields.** Never mutate the `state` argument.
+- Channel reducers handle merging — returning the full state causes duplicate data.
+
+```typescript
+// ✅ correct
+return { next_recipient: 'dev', signoffs: { po: true } };
+
+// ❌ wrong — direct mutation
+state.next_recipient = 'dev';
+return state;
+```
+
+### Persona workflow
+
+- Persona ordering is governed by `PERSONA_IDS` in `src/agents/personas.ts`. Do not rely on `Object.keys()` insertion order.
+- Each persona ends its response with `APPROVED` or `REJECTED: <reason>`. A rejection resets to `@isolate-po` and increments `rejectionCount`. After 5 rejections the orchestrator throws `RefinementIterationLimitError`.
+- `next_recipient: 'human_review'` is a special terminal node — it posts a GitHub pause comment and routes the graph to `__end__`.
+
+### SQLite checkpointing
+
+- The SQLite saver in `src/persistence/` uses parameterized queries only. Never interpolate runtime values into SQL strings.
+- Thread key is the GitHub Issue ID — `OrchestratorGraph` is initialized with a `dbPath`.
+
+## File Structure
+
+```
+src/
+├── agents/
+│   ├── index.ts        # AgentNode factory
+│   └── personas.ts     # PERSONA_IDS + persona definitions
+├── config/             # Model/LLM configuration
+├── github/             # GitHub comment posting helpers
+├── llm/                # LLM client wrappers (OpenAI / Anthropic)
+├── orchestrator/       # OrchestratorGraph class (LangGraph graph definition)
+├── persistence/
+│   ├── checkpoint.ts   # CheckpointSaver interface
+│   ├── langgraph-saver.ts  # SQLite-backed saver
+│   └── index.ts
+├── schema/
+│   ├── agent-state.ts  # AgentStateSchema (Zod) + type exports
+│   └── index.ts
+└── index.ts            # Public API — exports OrchestratorGraph
+```
+
+## Environment Variables
+
+Required at runtime (validated at startup in `apps/webhook-listener`):
+
+- `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` — at least one LLM key
+- `GITHUB_TOKEN` — PAT with `repo` scope for posting comments

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "local-registry": "verdaccio --config .verdaccio/config.yml",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "format:affected": "nx affected -t format -- --write --base=origin/main",
-    "format:check:affected": "nx affected -t format:check --base=origin/main",
+    "format:affected": "nx format:write --affected --base=origin/main",
+    "format:check:affected": "nx format:check --affected --base=origin/main",
     "lint:pr-title": "node scripts/lint-pr-title.mjs"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "local-registry": "verdaccio --config .verdaccio/config.yml",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "format:affected": "nx affected -t format -- --write --base=origin/main",
+    "format:check:affected": "nx affected -t format:check --base=origin/main",
     "lint:pr-title": "node scripts/lint-pr-title.mjs"
   },
   "private": true,


### PR DESCRIPTION
## Summary

Improves AI agent productivity across the monorepo by adding missing agent notes, expanding the always-on Copilot instructions with a project orientation section, and introducing a `Stop` lifecycle hook that auto-formats only the files touched in a session.

## Changes

- **`.github/copilot-instructions.md`** — added Project Orientation section (key paths, essential commands, links to AGENTS.md and A11Y_TESTING.md) so agents are immediately productive without having to explore the repo
- **`libs/ai-orchestrator/AGENTS.md`** — new agent notes for the most complex library; covers LangGraph return-only mutation rule, persona ordering, `human_review` terminal node, SQLite checkpoint patterns, and file structure
- **`apps/webhook-listener/AGENTS.md`** — new agent notes for the Fastify app; documents the required 8-step security pipeline order, command handlers, env vars, and secret-logging constraint
- **`.github/hooks/prettier-on-edit.json`** — new `Stop` lifecycle hook that runs `pnpm format:affected` once at the end of every agent session, formatting only changed/new files
- **`.github/prompts/create-component.prompt.md`** — new prompt (`/create-component`) that scaffolds a new React component library following the Blueprint pattern, including a11y tests and the quality gate
- **`package.json`** — added `format:affected` and `format:check:affected` scripts using Nx affected targeting

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.

## Deferred follow-ups

None