### PR TITLE
fix(ai-orchestrator): verify and enable JSON mode for mesh router LLM client

### DIFF
--- a/libs/ai-orchestrator/src/__tests__/mesh-router.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/mesh-router.spec.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { ChatOpenAI } from '@langchain/openai';
 import {
   analyzeMeshQuery,
   createMeshRouterNode,
   DEFAULT_MESH_CONFIG,
+  _test_createDefaultMeshClient,
   type MeshRouterConfig,
 } from '../orchestrator/mesh-router';
 import { createDefaultAgentState } from '../schema';
 import type { AgentState } from '../schema';
-import { _test_createDefaultMeshClient } from '../orchestrator/mesh-router';
-import { ChatOpenAI } from '@langchain/openai';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -311,7 +311,11 @@ describe('createMeshRouterNode', () => {
 });
 
 describe('_test_createDefaultMeshClient', () => {
-  const ORIGINAL_KEY = process.env['OPENAI_API_KEY'];
+  let ORIGINAL_KEY: string | undefined;
+
+  beforeEach(() => {
+    ORIGINAL_KEY = process.env['OPENAI_API_KEY'];
+  });
 
   afterEach(() => {
     if (ORIGINAL_KEY === undefined) {

--- a/libs/ai-orchestrator/src/__tests__/mesh-router.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/mesh-router.spec.ts
@@ -8,6 +8,8 @@ import {
 } from '../orchestrator/mesh-router';
 import { createDefaultAgentState } from '../schema';
 import type { AgentState } from '../schema';
+import { _test_createDefaultMeshClient } from '../orchestrator/mesh-router';
+import { ChatOpenAI } from '@langchain/openai';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -305,5 +307,31 @@ describe('createMeshRouterNode', () => {
     // Should silently fail safe without throwing
     const result = await node(state);
     expect(result).toEqual({});
+  });
+});
+
+describe('_test_createDefaultMeshClient', () => {
+  const ORIGINAL_KEY = process.env['OPENAI_API_KEY'];
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) {
+      delete process.env['OPENAI_API_KEY'];
+    } else {
+      process.env['OPENAI_API_KEY'] = ORIGINAL_KEY;
+    }
+  });
+
+  it('creates a ChatOpenAI client with JSON mode enabled', () => {
+    process.env['OPENAI_API_KEY'] = 'test-key';
+    const client = _test_createDefaultMeshClient();
+    expect(client).toBeInstanceOf(ChatOpenAI);
+    expect(client.modelKwargs?.['response_format']?.type).toBe('json_object');
+    expect(client.temperature).toBe(0);
+    expect(client.maxTokens).toBe(64);
+  });
+
+  it('throws if OPENAI_API_KEY is not set', () => {
+    delete process.env['OPENAI_API_KEY'];
+    expect(() => _test_createDefaultMeshClient()).toThrow(/OPENAI_API_KEY/);
   });
 });

--- a/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
+++ b/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
@@ -167,14 +167,12 @@ export function createMeshRouterNode(
   // Lazily resolve the client: if a client was injected (e.g. MockChatModel in
   // tests) use it directly; otherwise create the default on first invocation so
   // that OPENAI_API_KEY absence only throws when the node actually runs.
-  let resolvedClient: ChatOpenAI | undefined = config.llmClient as
-    | ChatOpenAI
-    | undefined;
+  let resolvedClient: BaseChatModel | undefined = config.llmClient;
 
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     if (!resolvedClient) {
       try {
-        resolvedClient = createDefaultMeshClient();
+        resolvedClient = createDefaultMeshClient() as unknown as BaseChatModel;
       } catch {
         // No API key available — mesh router is disabled for this run.
         // Fail safe: pass through unchanged rather than crashing the graph.
@@ -186,7 +184,8 @@ export function createMeshRouterNode(
 
     const { target } = await analyzeMeshQuery(
       state.messages ?? [],
-      resolvedClient,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      resolvedClient!,
     );
 
     // No ambiguous query detected — pass through unchanged (deterministic fallback)

--- a/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
+++ b/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
@@ -167,12 +167,12 @@ export function createMeshRouterNode(
   // Lazily resolve the client: if a client was injected (e.g. MockChatModel in
   // tests) use it directly; otherwise create the default on first invocation so
   // that OPENAI_API_KEY absence only throws when the node actually runs.
-  let resolvedClient: BaseChatModel | undefined = config.llmClient;
+  let resolvedClient: BaseChatModel | ChatOpenAI | undefined = config.llmClient;
 
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     if (!resolvedClient) {
       try {
-        resolvedClient = createDefaultMeshClient() as unknown as BaseChatModel;
+        resolvedClient = createDefaultMeshClient();
       } catch {
         // No API key available — mesh router is disabled for this run.
         // Fail safe: pass through unchanged rather than crashing the graph.
@@ -184,7 +184,7 @@ export function createMeshRouterNode(
 
     const { target } = await analyzeMeshQuery(
       state.messages ?? [],
-      resolvedClient,
+      resolvedClient as BaseChatModel,
     );
 
     // No ambiguous query detected — pass through unchanged (deterministic fallback)

--- a/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
+++ b/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
@@ -167,7 +167,9 @@ export function createMeshRouterNode(
   // Lazily resolve the client: if a client was injected (e.g. MockChatModel in
   // tests) use it directly; otherwise create the default on first invocation so
   // that OPENAI_API_KEY absence only throws when the node actually runs.
-  let resolvedClient: BaseChatModel | undefined = config.llmClient;
+  let resolvedClient: ChatOpenAI | undefined = config.llmClient as
+    | ChatOpenAI
+    | undefined;
 
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     if (!resolvedClient) {
@@ -228,8 +230,15 @@ export function createMeshRouterNode(
  * a small, fast model is perfectly suited and keeps orchestration overhead
  * negligible. temperature: 0 for deterministic routing decisions;
  * maxTokens: 64 since only a short JSON object is expected.
+ *
+ * JSON mode is enabled by passing `modelKwargs: { response_format: { type: 'json_object' } }`.
+ * This is the correct API surface for @langchain/openai v0.2.x. The `strict` flag is not required for
+ * `json_object` mode (only for `json_schema`).
+ *
+ * @returns {ChatOpenAI} Configured ChatOpenAI client for mesh routing
+ * @throws {Error} If OPENAI_API_KEY is not set
  */
-function createDefaultMeshClient(): BaseChatModel {
+function createDefaultMeshClient(): ChatOpenAI {
   const env = validateOrchestratorEnv();
   if (!env.OPENAI_API_KEY) {
     throw new Error(
@@ -244,5 +253,8 @@ function createDefaultMeshClient(): BaseChatModel {
     // JSON mode ensures the model always returns a valid JSON object,
     // reducing parse failures and making routing more deterministic.
     modelKwargs: { response_format: { type: 'json_object' } },
-  }) as unknown as BaseChatModel;
+  });
 }
+
+// Export for testing only; not part of the public API
+export { createDefaultMeshClient as _test_createDefaultMeshClient };

--- a/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
+++ b/libs/ai-orchestrator/src/orchestrator/mesh-router.ts
@@ -184,8 +184,7 @@ export function createMeshRouterNode(
 
     const { target } = await analyzeMeshQuery(
       state.messages ?? [],
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      resolvedClient!,
+      resolvedClient,
     );
 
     // No ambiguous query detected — pass through unchanged (deterministic fallback)


### PR DESCRIPTION
## Summary

Verified and enabled JSON mode for the mesh router's ChatOpenAI client. Confirmed `modelKwargs: { response_format: { type: 'json_object' } }` is the correct API surface for `@langchain/openai` v0.2.x. Removed unnecessary `as unknown as BaseChatModel` cast by changing `createDefaultMeshClient()` return type to `ChatOpenAI`. Added unit tests covering JSON mode configuration and error path.

## Changes

- **mesh-router.ts**: Changed `createDefaultMeshClient()` return type `BaseChatModel` → `ChatOpenAI`, removed double cast, exported as `_test_createDefaultMeshClient` for test-only usage, expanded JSDoc to clarify API surface and confirm `strict` flag not needed for `json_object` mode.
- **mesh-router.spec.ts**: Added `describe('_test_createDefaultMeshClient')` with two tests: one verifying JSON mode enabled (temperature=0, maxTokens=64), one verifying error path when `OPENAI_API_KEY` absent. Proper env var isolation in `beforeEach`/`afterEach`.

## Copilot Review Triage

- [x] **Blocker** (Security / Correctness)
- [x] **Major** (Reliability)
- [x] **Minor** (Coverage / Completeness)
- [x] **Nit** (Style)

All triage categories clean per pre-PR review.

## Deferred follow-ups

None.
