### PR TITLE
fix(ai-orchestrator): resolve LangGraph 1.3.0 checkpoint resumption and message merging bugs

### DIFF
--- a/apps/webhook-listener/src/commands/query.spec.ts
+++ b/apps/webhook-listener/src/commands/query.spec.ts
@@ -60,4 +60,53 @@ describe('handleQuery', () => {
       expect.objectContaining({ next_recipient: 'po' }),
     );
   });
+
+  it('does NOT clear pause_context when issued while paused', async () => {
+    // Simulate a thread paused at refinement_limit
+    // handleQuery relies on graph.invoke() to preserve pause_context from checkpoint
+    graph.getState.mockReturnValue({
+      next_recipient: null,
+      pause_context: 'refinement_limit',
+    });
+
+    await handleQuery(ctx, 'question');
+
+    // Verify that graph.invoke was called (NOT that pause_context is explicitly passed)
+    // The graph's invokeWithGraph() will preserve pause_context from checkpoint
+    expect(graph.invoke).toHaveBeenCalled();
+    const invokeCall = graph.invoke.mock.calls[0];
+    const invokePayload = invokeCall[1];
+
+    // Verify that pause_context is NOT explicitly cleared (not set to null in the call)
+    // If handleQuery passed pause_context: null, it would break /approve and /fix guards
+    expect(invokePayload.pause_context).not.toBe(null);
+    // Should be undefined here (relying on checkpoint preservation)
+    expect(invokePayload.pause_context).toBeUndefined();
+  });
+
+  it('preserves pause_context for approve/fix resumption guards', async () => {
+    // When a thread is paused with mesh_stalemate, pause_context must remain
+    // non-null so that /approve and /fix can guard against invalid state transitions.
+    // /query should NOT explicitly clear pause_context in its invoke call.
+    graph.getState.mockReturnValue({
+      next_recipient: null,
+      pause_context: 'mesh_stalemate',
+      mesh_origin: 'dev',
+    });
+
+    await handleQuery(ctx, 'question');
+
+    const invokeCall = graph.invoke.mock.calls[0];
+    const invokePayload = invokeCall[1];
+
+    // Critical: pause_context must NOT be explicitly set to null by /query
+    // /query should pass the delta message and next_recipient, letting the graph
+    // preserve pause_context from checkpoint. This ensures /approve and /fix
+    // can still check pause_context and detect the paused state.
+    expect(invokePayload.pause_context).not.toBe(null);
+    expect(invokePayload.pause_context).toBeUndefined();
+
+    // Verify next_recipient fallback logic still works
+    expect(invokePayload.next_recipient).toBe('po');
+  });
 });

--- a/libs/ai-orchestrator/src/__tests__/message-merging.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/message-merging.spec.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { OrchestratorGraph } from '../orchestrator';
+import { AgentState } from '../schema';
+import { findWorkspaceRoot } from '../config';
+
+// Locate workspace root via nx.json
+const AGENTS_MD_PATH = path.join(findWorkspaceRoot(process.cwd()), 'AGENTS.md');
+
+describe('Message merging with checkpoint resumption', () => {
+  const graphs: OrchestratorGraph[] = [];
+  const tempFiles: string[] = [];
+
+  function tempDbPath(): string {
+    const p = path.join(
+      os.tmpdir(),
+      `message-merge-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    tempFiles.push(p);
+    return p;
+  }
+
+  afterEach(() => {
+    graphs.forEach((g) => g.close());
+    graphs.length = 0;
+    tempFiles.forEach((f) => {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        // file may not exist
+      }
+    });
+    tempFiles.length = 0;
+  });
+
+  it('appends delta messages without duplication (single graph instance, multiple runs)', async () => {
+    // REQUIREMENT (from issue #67): When a thread is resumed multiple times with delta
+    // messages, the reducer must append messages exactly once each time.
+    // This test uses a SINGLE long-lived graph instance (like production webhook-listener)
+    // and verifies message append correctness across multiple run() calls.
+
+    const dbPath = tempDbPath();
+    const graph = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    // Run 1: Store initial message
+    await graph.run('merge-single-graph', {
+      messages: [{ type: 'human', content: 'message_1' }],
+    });
+
+    let state = graph.getState('merge-single-graph');
+    expect(state?.messages).toHaveLength(1);
+    expect(state?.messages[0].content).toBe('message_1');
+
+    // Run 2: Append delta message
+    await graph.run('merge-single-graph', {
+      messages: [{ type: 'human', content: 'message_2' }],
+    });
+
+    state = graph.getState('merge-single-graph');
+    expect(state?.messages).toHaveLength(2);
+    expect(state?.messages[0].content).toBe('message_1');
+    expect(state?.messages[1].content).toBe('message_2');
+
+    // Run 3: Append another delta message
+    await graph.run('merge-single-graph', {
+      messages: [{ type: 'human', content: 'message_3' }],
+    });
+
+    state = graph.getState('merge-single-graph');
+    expect(state?.messages).toHaveLength(3);
+    expect(state?.messages[0].content).toBe('message_1');
+    expect(state?.messages[1].content).toBe('message_2');
+    expect(state?.messages[2].content).toBe('message_3');
+  });
+
+  it('appends delta messages to checkpoint history without duplication on resume (ORIGINAL)', async () => {
+    // REQUIREMENT (from issue #67): When a thread is checkpointed and resumed
+    // with delta messages, the channel reducer should append messages exactly once.
+    // Scenario: run() stores msg_1 → close graph → new graph loads checkpoint →
+    // run with delta message (msg_2) → verify total is exactly 2, not duplicated
+
+    const dbPath = tempDbPath();
+
+    // --- Phase 1: Initial run stores first message ---
+    const graph1 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph1);
+
+    graph1.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    await graph1.run('merge-test-1', {
+      messages: [{ type: 'human', content: 'message_1' }],
+    });
+
+    const state1 = graph1.getState('merge-test-1');
+    expect(state1?.messages).toHaveLength(1);
+    expect(state1?.messages[0].content).toBe('message_1');
+
+    graph1.close();
+    graphs.pop();
+
+    // --- Phase 2: Resume with new graph, append delta message ---
+    const graph2 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph2);
+
+    // Register node that just stops (to load checkpoint and resume)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph2.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    // Resume using run() (which rebuilds the graph with registered nodes)
+    // passing delta message in the initial messages array
+    await graph2.run('merge-test-1', {
+      messages: [{ type: 'human', content: 'message_2' }],
+    });
+
+    // --- Verify: exactly 2 messages, no duplication ---
+    const state2 = graph2.getState('merge-test-1');
+    expect(state2?.messages).toHaveLength(2);
+    expect(state2?.messages[0].content).toBe('message_1');
+    expect(state2?.messages[1].content).toBe('message_2');
+
+    graph2.close();
+    graphs.pop();
+
+    // --- Phase 3: Resume again, append another message ---
+    const graph3 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph3);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph3.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    // Append msg_3 to the checkpoint that already has [msg_1, msg_2]
+    await graph3.run('merge-test-1', {
+      messages: [{ type: 'human', content: 'message_3' }],
+    });
+
+    // --- Verify: exactly 3 messages, no duplication ---
+    const state3 = graph3.getState('merge-test-1');
+    expect(state3?.messages).toHaveLength(3);
+    expect(state3?.messages[0].content).toBe('message_1');
+    expect(state3?.messages[1].content).toBe('message_2');
+    expect(state3?.messages[2].content).toBe('message_3');
+  });
+
+  it('preserves pause_context across checkpoint resumption', async () => {
+    // REQUIREMENT (from issue #67): When /query is issued while paused,
+    // it does NOT pass pause_context to invoke(). The invokeWithGraph() method
+    // merges checkpoint state with input, so pause_context is preserved from
+    // the checkpoint. This is critical for /approve and /fix guards.
+
+    const dbPath = tempDbPath();
+
+    // --- Phase 1: Set pause_context and store checkpoint ---
+    const graph1 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph1);
+
+    let poRun1 = false;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph1.registerNode('po', (_state: AgentState) => {
+      poRun1 = true;
+      return {
+        next_recipient: null,
+        pause_context: 'refinement_limit',
+      };
+    });
+
+    await graph1.run('pause-preserve-1', {
+      messages: [{ type: 'human', content: 'msg_1' }],
+    });
+
+    const state1 = graph1.getState('pause-preserve-1');
+    expect(state1?.pause_context).toBe('refinement_limit');
+    expect(poRun1).toBe(true);
+
+    graph1.close();
+    graphs.pop();
+
+    // --- Phase 2: Resume WITHOUT setting pause_context (simulating /query) ---
+    // Critical: invoke() does NOT pass pause_context, so it should be preserved from checkpoint
+    const graph2 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph2);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph2.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    // Invoke with delta message but NO pause_context (simulates /query)
+    await graph2.invoke('pause-preserve-1', {
+      next_recipient: 'po',
+      messages: [{ type: 'human', content: '@isolate- clarification?' }],
+      // NOT setting pause_context — should be preserved from checkpoint
+    });
+
+    // --- Verify: pause_context is preserved ---
+    const state2 = graph2.getState('pause-preserve-1');
+    expect(state2?.pause_context).toBe('refinement_limit');
+    expect(state2?.messages).toHaveLength(2);
+    expect(state2?.messages[1].content).toBe('@isolate- clarification?');
+
+    graph2.close();
+    graphs.pop();
+
+    // --- Phase 3: Clear pause_context (simulating /approve) ---
+    const graph3 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph3);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph3.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    // Invoke with explicit pause_context: null (simulates /approve)
+    await graph3.invoke('pause-preserve-1', {
+      next_recipient: 'po',
+      messages: [{ type: 'human', content: 'approved' }],
+      pause_context: null, // /approve explicitly clears this
+    });
+
+    // --- Verify: pause_context is now null ---
+    const state3 = graph3.getState('pause-preserve-1');
+    expect(state3?.pause_context).toBeNull();
+    expect(state3?.messages).toHaveLength(3);
+  });
+
+  it('handles multiple delta appends without message duplication', async () => {
+    // REQUIREMENT: Simulate a sequence of /query → /query → /fix
+    // Each resume appends delta messages. Final message count should be
+    // exactly 1 (initial) + 3 (deltas) = 4, not 5, 6, or more.
+
+    const dbPath = tempDbPath();
+
+    // --- Phase 1: Initial message ---
+    const graph1 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph1);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph1.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    await graph1.run('multi-delta-test', {
+      messages: [{ type: 'human', content: 'initial' }],
+    });
+
+    graph1.close();
+    graphs.pop();
+
+    // --- Phase 2: First /query (delta append) ---
+    const graph2 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph2);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph2.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    await graph2.invoke('multi-delta-test', {
+      next_recipient: 'po',
+      messages: [{ type: 'human', content: '@isolate- query_1' }],
+    });
+
+    graph2.close();
+    graphs.pop();
+
+    // --- Phase 3: Second /query (delta append) ---
+    const graph3 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph3);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph3.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    await graph3.invoke('multi-delta-test', {
+      next_recipient: 'po',
+      messages: [{ type: 'human', content: '@isolate- query_2' }],
+    });
+
+    graph3.close();
+    graphs.pop();
+
+    // --- Phase 4: /fix (delta append with pause_context clear) ---
+    const graph4 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph4);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph4.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    await graph4.invoke('multi-delta-test', {
+      next_recipient: 'po',
+      messages: [{ type: 'human', content: 'fixed' }],
+      pause_context: null,
+    });
+
+    // --- Verify: exactly 4 messages (initial + 3 deltas) ---
+    const finalState = graph4.getState('multi-delta-test');
+    expect(finalState?.messages).toHaveLength(4);
+
+    const contents = finalState?.messages.map((m) => m.content) || [];
+    expect(contents).toEqual([
+      'initial',
+      '@isolate- query_1',
+      '@isolate- query_2',
+      'fixed',
+    ]);
+  });
+});

--- a/libs/ai-orchestrator/src/__tests__/message-merging.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/message-merging.spec.ts
@@ -320,4 +320,61 @@ describe('Message merging with checkpoint resumption', () => {
       'fixed',
     ]);
   });
+
+  it('does not duplicate messages when resume input has no messages key', async () => {
+    // STEALTH BUG (issue #67): When invokeWithGraph receives an input that does
+    // NOT include a `messages` key (e.g. /query updating only next_recipient),
+    // the `...baseState` spread in parsedInput causes the full checkpoint
+    // history to flow into the channel reducer as the delta.
+    // The reducer then appends baseState.messages to the checkpoint, doubling.
+    //
+    // This test resumes with an input that has NO messages key and verifies
+    // the message count stays exactly the same.
+
+    const dbPath = tempDbPath();
+
+    // --- Phase 1: Store initial checkpoint with 2 messages ---
+    const graph1 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph1);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph1.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null, pause_context: 'refinement_limit' };
+    });
+
+    await graph1.run('no-messages-delta', {
+      messages: [
+        { type: 'human', content: 'msg_1' },
+        { type: 'human', content: 'msg_2' },
+      ],
+    });
+
+    const state1 = graph1.getState('no-messages-delta');
+    expect(state1?.messages).toHaveLength(2);
+
+    graph1.close();
+    graphs.pop();
+
+    // --- Phase 2: Resume with input that has NO messages key ---
+    // This simulates e.g. /approve updating pause_context but not sending a message
+    const graph2 = new OrchestratorGraph(dbPath, AGENTS_MD_PATH);
+    graphs.push(graph2);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graph2.registerNode('po', (_state: AgentState) => {
+      return { next_recipient: null };
+    });
+
+    await graph2.invoke('no-messages-delta', {
+      next_recipient: 'po',
+      pause_context: null,
+      // Intentionally NO messages key — should not trigger duplication
+    });
+
+    // --- Verify: message count unchanged at 2, not doubled to 4 ---
+    const state2 = graph2.getState('no-messages-delta');
+    expect(state2?.messages).toHaveLength(2);
+    expect(state2?.messages[0].content).toBe('msg_1');
+    expect(state2?.messages[1].content).toBe('msg_2');
+  });
 });

--- a/libs/ai-orchestrator/src/orchestrator/langgraph.ts
+++ b/libs/ai-orchestrator/src/orchestrator/langgraph.ts
@@ -516,24 +516,32 @@ export class OrchestratorGraph {
     };
 
     // Parse input through schema for validation.
-    // When input is provided alongside an existing checkpoint, spread the
-    // checkpoint state first so that scalar fields (next_recipient, counters,
-    // etc.) from the checkpoint are preserved unless explicitly overridden.
+    // When input is provided alongside an existing checkpoint, spread only the
+    // scalar fields from the checkpoint so that next_recipient, counters, etc.
+    // are preserved unless explicitly overridden by the caller.
     //
-    // IMPORTANT — do NOT pre-merge messages here. LangGraph's `messages`
-    // channel reducer already appends input messages to the checkpoint history
-    // (reducer: (x, y) => [...(x||[]), ...(y||[])]). Pre-merging would pass
-    // the full checkpoint history as y, causing every resume to duplicate the
-    // existing messages. Pass only the new message deltas via input.messages
-    // and let the channel reducer handle the append exactly once.
-    const baseState = existingCheckpoint ?? createDefaultAgentState();
+    // IMPORTANT — messages must NEVER be spread from the checkpoint here.
+    // LangGraph's `messages` channel reducer appends input.messages to the
+    // checkpoint history (reducer: (x, y) => [...(x||[]), ...(y||[])]).
+    // If we spread baseState (which includes full message history) into
+    // parsedInput, the reducer receives the full history as the delta y and
+    // doubles every message on each resume.
+    //
+    // Rule: only pass new message deltas (input.messages) to the graph.
+    // When the caller provides no messages key, pass an empty array so the
+    // reducer appends nothing — the checkpoint history is already stored and
+    // will be loaded by the checkpointer automatically.
+    const { messages: _prevMessages, ...baseStateWithoutMessages } =
+      existingCheckpoint ?? createDefaultAgentState();
+
     const parsedInput = input
       ? AgentStateSchema.parse({
-          ...baseState,
+          ...baseStateWithoutMessages,
           ...input,
+          messages: input.messages ?? [],
         })
       : existingCheckpoint
-        ? AgentStateSchema.parse(existingCheckpoint)
+        ? AgentStateSchema.parse({ ...baseStateWithoutMessages, messages: [] })
         : createDefaultAgentState();
 
     // Reset step counter — _step_count is per-invocation and must not carry

--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { LangGraphSqliteSaver } from './langgraph-saver';
+import type { RunnableConfig } from '@langchain/core/runnables';
+
+function makeTempDb(): string {
+  return path.join(
+    os.tmpdir(),
+    `saver-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+}
+
+function makeConfig(threadId: string): RunnableConfig {
+  return { configurable: { thread_id: threadId } };
+}
+
+function makeCheckpoint(id: string) {
+  return {
+    v: 4,
+    id,
+    ts: new Date().toISOString(),
+    channel_values: { messages: [] },
+    channel_versions: {},
+    versions_seen: {},
+    pending_sends: [],
+  };
+}
+
+function makeMetadata() {
+  return { source: 'input' as const, step: 0, writes: {}, parents: {} };
+}
+
+describe('LangGraphSqliteSaver', () => {
+  let saver: LangGraphSqliteSaver;
+  let dbPath: string;
+  const tempFiles: string[] = [];
+
+  beforeEach(() => {
+    dbPath = makeTempDb();
+    tempFiles.push(dbPath);
+    saver = new LangGraphSqliteSaver(dbPath);
+  });
+
+  afterEach(() => {
+    saver.close();
+    tempFiles.forEach((f) => {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        // ignore
+      }
+    });
+    tempFiles.length = 0;
+  });
+
+  describe('getTuple', () => {
+    it('returns undefined when no checkpoint exists for the thread', async () => {
+      const result = await saver.getTuple(makeConfig('nonexistent-thread'));
+      expect(result).toBeUndefined();
+    });
+
+    it('returns a CheckpointTuple object (not an array)', async () => {
+      const config = makeConfig('thread-1');
+      const checkpoint = makeCheckpoint('ckpt-1');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      const result = await saver.getTuple(config);
+
+      // Must be an object, not an array
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(false);
+      expect(typeof result).toBe('object');
+    });
+
+    it('returns CheckpointTuple with required config field', async () => {
+      const config = makeConfig('thread-2');
+      const checkpoint = makeCheckpoint('ckpt-2');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      const tuple = await saver.getTuple(config);
+
+      // LangGraph 1.3.0 reads tuple.config.configurable to find thread_id
+      expect(tuple).toHaveProperty('config');
+      expect(tuple?.config).toHaveProperty('configurable');
+      expect((tuple?.config?.configurable as any)?.['thread_id']).toBe(
+        'thread-2',
+      );
+    });
+
+    it('returns CheckpointTuple with checkpoint field', async () => {
+      const config = makeConfig('thread-3');
+      const checkpoint = makeCheckpoint('ckpt-3');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      const tuple = await saver.getTuple(config);
+
+      expect(tuple).toHaveProperty('checkpoint');
+      expect(tuple?.checkpoint?.id).toBe('ckpt-3');
+    });
+
+    it('returns CheckpointTuple with metadata field', async () => {
+      const config = makeConfig('thread-4');
+      const checkpoint = makeCheckpoint('ckpt-4');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      const tuple = await saver.getTuple(config);
+
+      expect(tuple).toHaveProperty('metadata');
+      expect(tuple?.metadata?.source).toBe('input');
+    });
+
+    it('returns pendingWrites as CheckpointPendingWrite[] tuples', async () => {
+      const config = makeConfig('thread-5');
+      const checkpoint = makeCheckpoint('ckpt-5');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      // putWrites now takes (config, writes, taskId)
+      const writeConfig = {
+        configurable: { thread_id: 'thread-5', checkpoint_id: 'ckpt-5' },
+      };
+      await saver.putWrites(writeConfig, [['messages', ['hello']]], 'task-1');
+
+      const tuple = await saver.getTuple(config);
+
+      // pendingWrites must be [taskId, channel, value][] — not [channel, value][]
+      expect(tuple?.pendingWrites).toBeDefined();
+      expect(Array.isArray(tuple?.pendingWrites)).toBe(true);
+      if (tuple?.pendingWrites?.length) {
+        const [taskId, channel] = tuple.pendingWrites[0];
+        expect(typeof taskId).toBe('string');
+        expect(typeof channel).toBe('string');
+      }
+    });
+  });
+
+  describe('put', () => {
+    it('returns a RunnableConfig (not void)', async () => {
+      const config = makeConfig('thread-put-1');
+      const checkpoint = makeCheckpoint('ckpt-put-1');
+      const metadata = makeMetadata();
+
+      const result = await saver.put(config, checkpoint, metadata, {});
+
+      // LangGraph 1.3.0 put must return RunnableConfig
+      expect(result).toBeDefined();
+      expect(typeof result).toBe('object');
+      expect(result).toHaveProperty('configurable');
+    });
+
+    it('returned RunnableConfig contains thread_id and checkpoint_id', async () => {
+      const config = makeConfig('thread-put-2');
+      const checkpoint = makeCheckpoint('ckpt-put-2');
+      const metadata = makeMetadata();
+
+      const result = await saver.put(config, checkpoint, metadata, {});
+
+      expect((result.configurable as any)?.['thread_id']).toBe('thread-put-2');
+      expect((result.configurable as any)?.['checkpoint_id']).toBe(
+        'ckpt-put-2',
+      );
+    });
+  });
+
+  describe('putWrites', () => {
+    it('accepts taskId as third argument (not checkpointId)', async () => {
+      const config = makeConfig('thread-writes-1');
+      const checkpoint = makeCheckpoint('ckpt-writes-1');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      // New signature: putWrites(config, writes: PendingWrite[], taskId: string)
+      // PendingWrite = [channel, value]
+      const writeConfig = {
+        configurable: {
+          thread_id: 'thread-writes-1',
+          checkpoint_id: 'ckpt-writes-1',
+        },
+      };
+      await expect(
+        saver.putWrites(writeConfig, [['messages', ['msg']]], 'task-abc'),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('list', () => {
+    it('is an async generator that yields CheckpointTuples', async () => {
+      const config = makeConfig('thread-list-1');
+      const checkpoint = makeCheckpoint('ckpt-list-1');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      const results: unknown[] = [];
+      for await (const tuple of saver.list(config)) {
+        results.push(tuple);
+      }
+
+      expect(results.length).toBeGreaterThan(0);
+      // Each result must be a CheckpointTuple object
+      const first = results[0] as any;
+      expect(Array.isArray(first)).toBe(false);
+      expect(first).toHaveProperty('config');
+      expect(first).toHaveProperty('checkpoint');
+    });
+
+    it('yields no results for an unknown thread', async () => {
+      const results: unknown[] = [];
+      for await (const tuple of saver.list(makeConfig('unknown-thread'))) {
+        results.push(tuple);
+      }
+      expect(results).toHaveLength(0);
+    });
+  });
+});

--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
@@ -193,6 +193,25 @@ describe('LangGraphSqliteSaver', () => {
         saver.putWrites(writeConfig, [['messages', ['msg']]], 'task-abc'),
       ).resolves.not.toThrow();
     });
+
+    it('throws when checkpoint_id is missing from config', async () => {
+      // Per error-path testing: ensure putWrites rejects if checkpoint_id is absent
+      // (caller forgot to call put() first or pass the wrong config)
+      const configMissingCheckpointId = {
+        configurable: {
+          thread_id: 'thread-writes-2',
+          // checkpoint_id intentionally missing
+        },
+      };
+
+      await expect(
+        saver.putWrites(
+          configMissingCheckpointId,
+          [['messages', ['msg']]],
+          'task-xyz',
+        ),
+      ).rejects.toThrow('checkpoint_id is required');
+    });
   });
 
   describe('list', () => {
@@ -222,6 +241,38 @@ describe('LangGraphSqliteSaver', () => {
         results.push(tuple);
       }
       expect(results).toHaveLength(0);
+    });
+
+    it('rejects (async generator error path) when statement.all() throws', async () => {
+      // Per repo testing guidelines, error-path tests required for exported async APIs.
+      // Mock the underlying stmtGetAllByThread to throw an error and verify
+      // the async generator properly propagates the rejection.
+      const config = makeConfig('thread-error');
+      const checkpoint = makeCheckpoint('ckpt-error');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      // Monkey-patch the private stmtGetAllByThread to throw
+      const originalStmt = (saver as any).stmtGetAllByThread;
+      (saver as any).stmtGetAllByThread = {
+        all: () => {
+          throw new Error('Database error: simulated failure');
+        },
+      };
+
+      try {
+        // Attempt to iterate the generator — should raise the error
+        const generator = saver.list(config);
+        await generator.next(); // First call triggers the .all() error
+        // If we get here, the test should fail
+        throw new Error('Expected list() to raise on generator iteration');
+      } catch (err) {
+        expect((err as Error).message).toContain('Database error');
+      } finally {
+        // Restore original statement
+        (saver as any).stmtGetAllByThread = originalStmt;
+      }
     });
   });
 });

--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { randomUUID } from 'crypto';
 import Database = require('better-sqlite3');
 import { BaseCheckpointSaver } from '@langchain/langgraph';
+import type { CheckpointTuple } from '@langchain/langgraph-checkpoint';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import { AgentState } from '../schema';
 
@@ -26,6 +27,7 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
   private db: Database.Database;
   private stmtUpsert!: Database.Statement;
   private stmtGetLatest!: Database.Statement;
+  private stmtGetAllByThread!: Database.Statement;
   private stmtGetWriteVersion!: Database.Statement;
   private txPutTuple!: (
     configurable: Record<string, any>,
@@ -73,6 +75,7 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
       CREATE TABLE IF NOT EXISTS checkpoint_writes (
         thread_id TEXT NOT NULL,
         checkpoint_id TEXT NOT NULL,
+        task_id TEXT NOT NULL DEFAULT 'default',
         channel TEXT NOT NULL,
         version INTEGER NOT NULL,
         data BLOB NOT NULL,
@@ -109,6 +112,13 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
       LIMIT 1
     `);
 
+    this.stmtGetAllByThread = this.db.prepare(`
+      SELECT checkpoint_id, checkpoint_body, metadata_body
+      FROM checkpoints
+      WHERE thread_id = ?
+      ORDER BY sequence DESC
+    `);
+
     this.stmtGetWriteVersion = this.db.prepare(`
       SELECT MAX(version) as max_version
       FROM checkpoint_writes
@@ -135,59 +145,78 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
 
   /**
    * Get the latest checkpoint for a thread.
-   * Implements LangGraph's BaseCheckpointSaver.getTuple().
-   * Loads persisted channel writes to support resumption/replay semantics.
+   * Implements LangGraph 1.3.0 BaseCheckpointSaver.getTuple().
+   * Returns a CheckpointTuple object (not an array).
    */
   public async getTuple(
     config: RunnableConfig,
-  ): Promise<[checkpoint: any, metadata: any, writes: any[]] | null> {
+  ): Promise<CheckpointTuple | undefined> {
     const threadId = (config.configurable as any)?.['thread_id'] || 'default';
     const row = this.stmtGetLatest.get(threadId) as any;
 
     if (!row) {
-      return null;
+      return undefined;
     }
 
-    // Load channel writes for proper checkpoint restore semantics
+    // Load pending writes — each stored as [task_id, channel, value]
     const writesRows = this.db
       .prepare(
-        `SELECT channel, version, data FROM checkpoint_writes
+        `SELECT task_id, channel, data FROM checkpoint_writes
          WHERE thread_id = ? AND checkpoint_id = ?
-         ORDER BY version DESC`,
+         ORDER BY version ASC`,
       )
       .all(threadId, row.checkpoint_id) as any[];
 
-    const writes = writesRows.map((w: any) => [w.channel, JSON.parse(w.data)]);
+    const pendingWrites: [string, string, unknown][] = writesRows.map(
+      (w: any) => [w.task_id, w.channel, JSON.parse(w.data)],
+    );
 
-    return [
-      JSON.parse(row.checkpoint_body),
-      JSON.parse(row.metadata_body),
-      writes,
-    ];
+    const tupleConfig: RunnableConfig = {
+      configurable: { thread_id: threadId, checkpoint_id: row.checkpoint_id },
+    };
+
+    return {
+      config: tupleConfig,
+      checkpoint: JSON.parse(row.checkpoint_body),
+      metadata: JSON.parse(row.metadata_body),
+      pendingWrites,
+    };
   }
 
   /**
    * Save a checkpoint.
-   * Implements LangGraph's BaseCheckpointSaver.put().
+   * Implements LangGraph 1.3.0 BaseCheckpointSaver.put().
+   * Returns the RunnableConfig for the saved checkpoint.
    */
   public async put(
     config: RunnableConfig,
     checkpoint: any,
     metadata: any,
-  ): Promise<void> {
-    this.txPutTuple(config.configurable || {}, checkpoint, metadata);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _newVersions?: Record<string, unknown>,
+  ): Promise<RunnableConfig> {
+    const configurable = config.configurable || {};
+    this.txPutTuple(configurable, checkpoint, metadata);
+    const threadId = (configurable as any)['thread_id'] || 'default';
+    const checkpointId = checkpoint.id || 'default';
+    return {
+      configurable: { thread_id: threadId, checkpoint_id: checkpointId },
+    };
   }
 
   /**
    * Save writes (channel updates) to a checkpoint.
-   * Implements LangGraph's BaseCheckpointSaver.putWrites().
+   * Implements LangGraph 1.3.0 BaseCheckpointSaver.putWrites().
+   * Third argument is taskId (not checkpointId) per the 1.3.0 interface.
    */
   public async putWrites(
     config: RunnableConfig,
-    writes: Array<[string, any]>,
-    checkpointId: string,
+    writes: Array<[string, unknown]>,
+    taskId: string,
   ): Promise<void> {
     const threadId = (config.configurable as any)?.['thread_id'] || 'default';
+    const checkpointId =
+      (config.configurable as any)?.['checkpoint_id'] || 'default';
 
     // Ensure checkpoint exists before inserting writes
     const existing = this.db
@@ -209,8 +238,8 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
     // Wrap version lookup and insert in transaction to prevent race conditions
     this.db.transaction(() => {
       const stmt = this.db.prepare(`
-        INSERT INTO checkpoint_writes (thread_id, checkpoint_id, channel, version, data)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO checkpoint_writes (thread_id, checkpoint_id, task_id, channel, version, data)
+        VALUES (?, ?, ?, ?, ?, ?)
       `);
 
       for (const [channel, data] of writes) {
@@ -226,12 +255,34 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
         stmt.run(
           threadId,
           checkpointId,
+          taskId,
           channel,
           version,
           JSON.stringify(data),
         );
       }
     })();
+  }
+
+  /**
+   * List all checkpoints for a thread.
+   * Implements LangGraph 1.3.0 BaseCheckpointSaver.list().
+   */
+  public async *list(config: RunnableConfig): AsyncGenerator<CheckpointTuple> {
+    const threadId = (config.configurable as any)?.['thread_id'] || 'default';
+    const rows = this.stmtGetAllByThread.all(threadId) as any[];
+
+    for (const row of rows) {
+      const tupleConfig: RunnableConfig = {
+        configurable: { thread_id: threadId, checkpoint_id: row.checkpoint_id },
+      };
+      yield {
+        config: tupleConfig,
+        checkpoint: JSON.parse(row.checkpoint_body),
+        metadata: JSON.parse(row.metadata_body),
+        pendingWrites: [],
+      };
+    }
   }
 
   /**

--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
@@ -105,9 +105,19 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
           ADD COLUMN task_id TEXT NOT NULL DEFAULT 'default';
         `);
       }
-    } catch {
-      // If migration fails (e.g., table doesn't exist yet), that's fine.
-      // The CREATE TABLE IF NOT EXISTS above will handle it on first use.
+    } catch (err) {
+      // Only swallow errors if table doesn't exist yet (expected during first initialization).
+      // For other errors (e.g., locked DB, constraint violation), log a warning so
+      // migration failures are surfaced rather than silently failing later.
+      const errMsg = (err as Error).message || '';
+      const isTableNotExist = errMsg.includes('no such table');
+      const isDuplicateColumn = errMsg.includes('duplicate column');
+      if (!isTableNotExist && !isDuplicateColumn) {
+        console.warn(
+          '[LangGraphSqliteSaver] schema migration may have failed:',
+          errMsg,
+        );
+      }
     }
   }
 
@@ -217,12 +227,12 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
   ): Promise<RunnableConfig> {
     const configurable = config.configurable || {};
     const threadId = (configurable as any)['thread_id'] || 'default';
-    // CRITICAL: Compute checkpointId once to match txPutTuple's logic.
-    // txPutTuple uses: checkpoint.id || randomUUID()
-    // Must use the same logic here to return the ID that was actually stored.
-    // If we returned 'default' while storing a randomUUID, callers would get
-    // the wrong checkpoint_id for subsequent putWrites() calls.
+    // CRITICAL: Compute checkpointId once and assign to checkpoint so txPutTuple
+    // uses the same ID for both storage and return value.
+    // If checkpoint.id is falsy, generate a UUID and use it consistently.
     const checkpointId = checkpoint.id || randomUUID();
+    // Assign back to checkpoint so txPutTuple's internal computation uses the same ID
+    checkpoint.id = checkpointId;
     this.txPutTuple(configurable, checkpoint, metadata);
     return {
       configurable: { thread_id: threadId, checkpoint_id: checkpointId },
@@ -240,8 +250,17 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
     taskId: string,
   ): Promise<void> {
     const threadId = (config.configurable as any)?.['thread_id'] || 'default';
-    const checkpointId =
-      (config.configurable as any)?.['checkpoint_id'] || 'default';
+    const checkpointId = (config.configurable as any)?.['checkpoint_id'];
+
+    // checkpoint_id is required — do not default to 'default'.
+    // If missing, it indicates an upstream error (put() should have returned it).
+    // Requiring it here prevents silent corruption if called with incomplete config.
+    if (!checkpointId) {
+      throw new Error(
+        '[LangGraphSqliteSaver.putWrites] checkpoint_id is required in config.configurable. ' +
+          'Did you call put() first to get the checkpoint_id?',
+      );
+    }
 
     // Ensure checkpoint exists before inserting writes
     const existing = this.db

--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
@@ -59,6 +59,8 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
 
   /**
    * Initialize LangGraph checkpoint schema.
+   * Handles both new database creation and migration of existing databases
+   * (e.g., adding task_id column when not present).
    */
   private initSchema(): void {
     this.db.exec(`
@@ -89,6 +91,24 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
       CREATE INDEX IF NOT EXISTS idx_writes_thread ON checkpoint_writes(thread_id);
       CREATE INDEX IF NOT EXISTS idx_writes_version_lookup ON checkpoint_writes(thread_id, checkpoint_id, channel, version);
     `);
+
+    // Migrate existing checkpoint_writes table: add task_id column if missing.
+    // PRAGMA table_info returns empty result if table doesn't exist, so this is safe.
+    try {
+      const columns = this.db
+        .prepare('PRAGMA table_info(checkpoint_writes)')
+        .all() as Array<{ name: string }>;
+      const hasTaskId = columns.some((col) => col.name === 'task_id');
+      if (!hasTaskId) {
+        this.db.exec(`
+          ALTER TABLE checkpoint_writes
+          ADD COLUMN task_id TEXT NOT NULL DEFAULT 'default';
+        `);
+      }
+    } catch {
+      // If migration fails (e.g., table doesn't exist yet), that's fine.
+      // The CREATE TABLE IF NOT EXISTS above will handle it on first use.
+    }
   }
 
   /**
@@ -196,9 +216,14 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
     _newVersions?: Record<string, unknown>,
   ): Promise<RunnableConfig> {
     const configurable = config.configurable || {};
-    this.txPutTuple(configurable, checkpoint, metadata);
     const threadId = (configurable as any)['thread_id'] || 'default';
-    const checkpointId = checkpoint.id || 'default';
+    // CRITICAL: Compute checkpointId once to match txPutTuple's logic.
+    // txPutTuple uses: checkpoint.id || randomUUID()
+    // Must use the same logic here to return the ID that was actually stored.
+    // If we returned 'default' while storing a randomUUID, callers would get
+    // the wrong checkpoint_id for subsequent putWrites() calls.
+    const checkpointId = checkpoint.id || randomUUID();
+    this.txPutTuple(configurable, checkpoint, metadata);
     return {
       configurable: { thread_id: threadId, checkpoint_id: checkpointId },
     };


### PR DESCRIPTION
## Summary

Resolves issues #67 and #88. Fixes two related bugs discovered via TDD:
1. `LangGraphSqliteSaver.getTuple()` returned a legacy array instead of a `CheckpointTuple` object, crashing LangGraph 1.3.0 on any checkpoint resumption
2. `invokeWithGraph()` spread full checkpoint message history into `parsedInput`, causing message duplication on every resume where `messages` was omitted from the input delta

## Changes

- `libs/ai-orchestrator/src/persistence/langgraph-saver.ts` — updated `getTuple`, `put`, `putWrites`, and `list` to conform to LangGraph 1.3.0 `CheckpointTuple` interface
- `libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts` — 11 unit tests for the saver interface
- `libs/ai-orchestrator/src/orchestrator/langgraph.ts` — destructure `messages` out of `baseState` in `invokeWithGraph()` to ensure only delta messages flow to the channel reducer
- `libs/ai-orchestrator/src/__tests__/message-merging.spec.ts` — 5 integration tests validating checkpoint resumption, pause_context preservation, and message merging correctness
- `apps/webhook-listener/src/commands/query.spec.ts` — 2 unit tests validating pause_context is not cleared by `/query`

## Copilot Review Triage

- [x] Blocker — none
- [x] Major — none
- [x] Minor — tracked as follow-up issues (see below)
- [x] Nit — test count in summary corrected to 5

## Deferred follow-ups

- #89 — add rejection-path test for `LangGraphSqliteSaver.getTuple()`
- #90 — add rejection-path test for `LangGraphSqliteSaver.putWrites()`