### PR TITLE
feat(ai-orchestrator): add checkpoint_id-specific lookup to getTuple and E2E resumption test

### DIFF
--- a/libs/ai-orchestrator/src/__tests__/refinement-loop.e2e.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/refinement-loop.e2e.spec.ts
@@ -384,4 +384,53 @@ describe.skipIf(!sqliteAvailable)('Refinement Loop — E2E', () => {
       qa: true,
     });
   });
+
+  // ── Checkpoint resumption: same threadId re-invoke loads prior state ───────
+
+  it('loads prior checkpoint when same threadId is reused on second invoke', async () => {
+    const graph = makeGraph();
+
+    graph.registerRefinementNode('po', approvalNode('po'));
+    graph.registerRefinementNode('dev', approvalNode('dev'));
+    graph.registerRefinementNode('qa', approvalNode('qa'));
+
+    const threadId = 'issue-same-thread-resumption';
+
+    // First invoke: full loop completes, checkpoint is persisted
+    const firstResult = await graph.invoke(threadId, {
+      metadata: { github_issue_id: 'same-thread-resume' },
+    });
+    expect(firstResult.status).toBe('completed');
+    expect(firstResult.finalState.signoffs).toMatchObject({
+      po: true,
+      dev: true,
+      qa: true,
+    });
+    const firstMessageCount = firstResult.finalState.messages.length;
+    expect(firstMessageCount).toBeGreaterThan(0);
+
+    // Second invoke with the same threadId: invokeWithGraph loads the persisted
+    // checkpoint via getLatest(), applies the delta input on top, then runs the
+    // graph again.  The messages reducer appends each persona's new messages to
+    // the checkpoint's existing history — proving the checkpoint was loaded.
+    const secondResult = await graph.invoke(threadId, {
+      next_recipient: 'po',
+      signoffs: {},
+      rejectionCount: 0,
+      rejectionReason: '',
+      metadata: { github_issue_id: 'same-thread-resume' },
+    });
+    expect(secondResult.status).toBe('completed');
+    expect(secondResult.finalState.signoffs).toMatchObject({
+      po: true,
+      dev: true,
+      qa: true,
+    });
+
+    // The second run appended new persona messages on top of the checkpoint's
+    // existing message history, so the total must exceed the first run's count.
+    expect(secondResult.finalState.messages.length).toBeGreaterThan(
+      firstMessageCount,
+    );
+  });
 });

--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
@@ -143,6 +143,50 @@ describe('LangGraphSqliteSaver', () => {
         expect(typeof channel).toBe('string');
       }
     });
+
+    it('returns specific checkpoint when config.configurable.checkpoint_id is provided', async () => {
+      const config = makeConfig('thread-specific');
+      const checkpointA = makeCheckpoint('ckpt-a');
+      const checkpointB = makeCheckpoint('ckpt-b');
+      const metadata = makeMetadata();
+
+      // Put two checkpoints for the same thread — ckpt-b is the latest
+      await saver.put(config, checkpointA, metadata, {});
+      await saver.put(config, checkpointB, metadata, {});
+
+      // Request the older checkpoint by explicit checkpoint_id
+      const specificConfig: RunnableConfig = {
+        configurable: { thread_id: 'thread-specific', checkpoint_id: 'ckpt-a' },
+      };
+      const tuple = await saver.getTuple(specificConfig);
+
+      // Must return ckpt-a, not the latest ckpt-b
+      expect(tuple).toBeDefined();
+      expect(tuple?.checkpoint?.id).toBe('ckpt-a');
+      // The returned config must echo back the requested checkpoint_id
+      expect((tuple?.config?.configurable as any)?.['checkpoint_id']).toBe(
+        'ckpt-a',
+      );
+    });
+
+    it('returns undefined when a specific checkpoint_id is provided but not found', async () => {
+      const config = makeConfig('thread-specific-miss');
+      const checkpoint = makeCheckpoint('ckpt-exists');
+      const metadata = makeMetadata();
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      // Request a checkpoint_id that was never stored
+      const missConfig: RunnableConfig = {
+        configurable: {
+          thread_id: 'thread-specific-miss',
+          checkpoint_id: 'ckpt-does-not-exist',
+        },
+      };
+      const result = await saver.getTuple(missConfig);
+
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('put', () => {

--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.ts
@@ -27,6 +27,7 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
   private db: Database.Database;
   private stmtUpsert!: Database.Statement;
   private stmtGetLatest!: Database.Statement;
+  private stmtGetById!: Database.Statement;
   private stmtGetAllByThread!: Database.Statement;
   private stmtGetWriteVersion!: Database.Statement;
   private txPutTuple!: (
@@ -142,6 +143,12 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
       LIMIT 1
     `);
 
+    this.stmtGetById = this.db.prepare(`
+      SELECT checkpoint_id, checkpoint_body, metadata_body
+      FROM checkpoints
+      WHERE thread_id = ? AND checkpoint_id = ?
+    `);
+
     this.stmtGetAllByThread = this.db.prepare(`
       SELECT checkpoint_id, checkpoint_body, metadata_body
       FROM checkpoints
@@ -182,7 +189,13 @@ export class LangGraphSqliteSaver extends (BaseCheckpointSaver as any) {
     config: RunnableConfig,
   ): Promise<CheckpointTuple | undefined> {
     const threadId = (config.configurable as any)?.['thread_id'] || 'default';
-    const row = this.stmtGetLatest.get(threadId) as any;
+    const requestedCheckpointId = (config.configurable as any)?.[
+      'checkpoint_id'
+    ] as string | undefined;
+
+    const row = requestedCheckpointId
+      ? (this.stmtGetById.get(threadId, requestedCheckpointId) as any)
+      : (this.stmtGetLatest.get(threadId) as any);
 
     if (!row) {
       return undefined;


### PR DESCRIPTION
## Summary

Update `LangGraphSqliteSaver.getTuple()` to support fetching a specific checkpoint by `checkpoint_id` when provided in `config.configurable`. Previously `getTuple()` always returned the latest checkpoint, ignoring any `checkpoint_id` in the config. LangGraph 1.3.0 passes a specific `checkpoint_id` during resumption — this fix ensures the correct snapshot is loaded. Also adds an E2E resumption test that reuses the same `threadId` across two invocations, verifying the checkpoint is loaded and message history accumulates correctly. Follow-up to PR #78.

## Changes

- **`langgraph-saver.ts`**: Added `stmtGetById` prepared statement (`SELECT … WHERE thread_id = ? AND checkpoint_id = ?`). `getTuple()` now branches: if `config.configurable.checkpoint_id` is present it uses `stmtGetById`, otherwise falls back to `stmtGetLatest`.
- **`langgraph-saver.spec.ts`**: Two new `getTuple` tests — specific `checkpoint_id` found (happy path) and specific `checkpoint_id` not found (error path, returns `undefined`).
- **`refinement-loop.e2e.spec.ts`**: New E2E test `'loads prior checkpoint when same threadId is reused on second invoke'` — runs the full PO→Dev→QA loop twice with the same `threadId`, asserts that message history accumulates across invocations.

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.

## Deferred follow-ups

None