### PR TITLE
test(ai-orchestrator): cover getTuple database errors

### DIFF
--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
@@ -187,6 +187,24 @@ describe('LangGraphSqliteSaver', () => {
 
       expect(result).toBeUndefined();
     });
+
+    it('rejects when the latest checkpoint statement throws', async () => {
+      const originalStmt = (saver as any).stmtGetLatest;
+      const expectedError = new Error('DB Locked');
+      (saver as any).stmtGetLatest = {
+        get: () => {
+          throw expectedError;
+        },
+      };
+
+      try {
+        await expect(
+          saver.getTuple(makeConfig('thread-db-error')),
+        ).rejects.toThrow('DB Locked');
+      } finally {
+        (saver as any).stmtGetLatest = originalStmt;
+      }
+    });
   });
 
   describe('put', () => {


### PR DESCRIPTION
## Summary

Adds regression coverage for the `LangGraphSqliteSaver.getTuple()` database-error path requested in #89.

Closes #89.

## Changes

- Adds a `langgraph-saver.spec.ts` test that monkey-patches the private `stmtGetLatest` statement to throw.
- Asserts `getTuple()` rejects with the original database error instead of swallowing it.
- Restores the original statement in `finally` to avoid leaking test state.

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

Validation performed:

- `pnpm install --ignore-scripts`
- `pnpm rebuild better-sqlite3`
- `NX_DAEMON=false pnpm nx test ai-orchestrator -- --run src/persistence/langgraph-saver.spec.ts -t "latest checkpoint statement"`
- `NX_DAEMON=false pnpm nx test ai-orchestrator -- --run src/persistence/langgraph-saver.spec.ts`
- `pnpm exec prettier --check libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts`
- `NX_DAEMON=false pnpm nx typecheck ai-orchestrator`
- `NX_DAEMON=false pnpm nx lint ai-orchestrator` (passes with existing warnings)

## Deferred follow-ups

None.
