### PR TITLE
test(ai-orchestrator): cover putWrites insert errors

### DIFF
--- a/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
+++ b/libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts
@@ -256,6 +256,41 @@ describe('LangGraphSqliteSaver', () => {
         ),
       ).rejects.toThrow('checkpoint_id is required');
     });
+
+    it('rejects when the internal insert statement throws', async () => {
+      const config = makeConfig('thread-writes-insert-error');
+      const checkpoint = makeCheckpoint('ckpt-writes-insert-error');
+      const metadata = makeMetadata();
+      const writeConfig = {
+        configurable: {
+          thread_id: 'thread-writes-insert-error',
+          checkpoint_id: 'ckpt-writes-insert-error',
+        },
+      };
+
+      await saver.put(config, checkpoint, metadata, {});
+
+      const originalPrepare = (saver as any).db.prepare;
+      const expectedError = new Error('insert failed');
+      (saver as any).db.prepare = function (sql: string) {
+        if (sql.includes('INSERT INTO checkpoint_writes')) {
+          return {
+            run: () => {
+              throw expectedError;
+            },
+          };
+        }
+        return originalPrepare.call(this, sql);
+      };
+
+      try {
+        await expect(
+          saver.putWrites(writeConfig, [['messages', ['msg']]], 'task-insert'),
+        ).rejects.toThrow('insert failed');
+      } finally {
+        (saver as any).db.prepare = originalPrepare;
+      }
+    });
   });
 
   describe('list', () => {


### PR DESCRIPTION
## Summary

Adds regression coverage for the `LangGraphSqliteSaver.putWrites()` insert-error path requested in #90.

Closes #90.

## Changes

- Adds a `langgraph-saver.spec.ts` test that monkey-patches the private SQLite `db.prepare` method.
- Makes only the `INSERT INTO checkpoint_writes` statement return a throwing `run()` implementation.
- Asserts `putWrites()` rejects with the thrown insert error.
- Restores the original `prepare` implementation in `finally` to avoid leaking test state.

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

Validation performed:

- `NX_DAEMON=false pnpm nx test ai-orchestrator -- --run src/persistence/langgraph-saver.spec.ts -t "internal insert statement"`
- `NX_DAEMON=false pnpm nx test ai-orchestrator -- --run src/persistence/langgraph-saver.spec.ts`
- `pnpm exec prettier --check libs/ai-orchestrator/src/persistence/langgraph-saver.spec.ts`
- `NX_DAEMON=false pnpm nx typecheck ai-orchestrator`
- `NX_DAEMON=false pnpm nx lint ai-orchestrator` (passes with existing warnings)

## Deferred follow-ups

None.
