### PR TITLE
fix(tsconfig): suppress node10 resolution deprecation

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,


### PR DESCRIPTION
## Summary

Suppresses the TypeScript `moduleResolution=node10` deprecation warning requested in #77 by adding `ignoreDeprecations` to the workspace base TypeScript config.

Closes #77.

Note: the issue text mentions `"ignoreDeprecations": "6.0"`, but this repository currently uses TypeScript 5.9.3, where `6.0` is rejected with `TS5103: Invalid value for '--ignoreDeprecations'`. `"5.0"` is the valid value for this compiler version and successfully suppresses the node10 deprecation warning while keeping typecheck green.

## Changes

- Adds `"ignoreDeprecations": "5.0"` to `tsconfig.base.json`.
- Confirmed no other `tsconfig*.json` files override `moduleResolution` or `ignoreDeprecations`.

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

Validation performed:

- `pnpm exec prettier --check tsconfig.base.json`
- `NX_DAEMON=false pnpm nx run-many --target=typecheck`
- `NX_DAEMON=false pnpm nx run-many --target=lint --all` (passes with existing warnings)

## Deferred follow-ups

None.
