### PR TITLE
feat(source): add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,132 @@
+name: 🐛 Bug Report
+description: Report a defect or unexpected behavior
+title: 'fix: [brief description]'
+labels: ['type: bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please provide as much detail as possible to help us reproduce and fix the issue quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear summary of what's not working.
+      placeholder: "The Button component doesn't respond to keyboard input in disabled state."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Render Button with `disabled` prop
+        2. Tab to the button
+        3. Press Enter
+        4. Button still responds (should not respond)
+      validations:
+        required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen instead?
+      placeholder: 'Disabled button should not respond to keyboard input or clicks.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens?
+      placeholder: 'Disabled button still triggers onClick handler on Enter key press.'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component (if applicable)
+      description: Which component has the issue?
+      options:
+        - Select a component...
+        - Button
+        - Dropdown
+        - Dialog
+        - Other (please specify in description)
+      validations:
+        required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Package Version
+      description: What version of `@isolate-ui/*` are you using? (e.g., 1.0.0 or main branch)
+      placeholder: '1.0.0 or main'
+      validations:
+        required: false
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Where does the issue occur?
+      options:
+        - Browser (specify version in details)
+        - Node.js (Vitest, Node utilities)
+        - Build/tooling
+        - Other
+      validations:
+        required: false
+
+  - type: textarea
+    id: environment-details
+    attributes:
+      label: Environment Details
+      description: |
+        OS, browser version, pnpm version, Node.js version, etc.
+      placeholder: |
+        - OS: macOS 14.6
+        - Browser: Chrome 125
+        - Node.js: 22.x
+        - pnpm: 10.30.3
+      validations:
+        required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output or Error Message
+      description: Paste any error messages, console output, or stack traces (if applicable).
+      placeholder: |
+        ```
+        TypeError: Cannot read property 'onClick' of undefined
+          at Button (button.tsx:42)
+        ```
+      validations:
+        required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, links to CodeSandbox reproduction, or any other relevant context.
+      validations:
+        required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I've searched existing issues to ensure this bug hasn't been reported
+          required: true
+        - label: I've provided clear reproduction steps
+          required: true
+        - label: I've included relevant environment information
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,8 +27,8 @@ body:
         2. Tab to the button
         3. Press Enter
         4. Button still responds (should not respond)
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: expected
@@ -59,8 +59,8 @@ body:
         - Dropdown
         - Dialog
         - Other (please specify in description)
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: input
     id: version
@@ -68,8 +68,8 @@ body:
       label: Package Version
       description: What version of `@isolate-ui/*` are you using? (e.g., 1.0.0 or main branch)
       placeholder: '1.0.0 or main'
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: dropdown
     id: environment
@@ -81,8 +81,8 @@ body:
         - Node.js (Vitest, Node utilities)
         - Build/tooling
         - Other
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: textarea
     id: environment-details
@@ -95,8 +95,8 @@ body:
         - Browser: Chrome 125
         - Node.js: 22.x
         - pnpm: 10.30.3
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: textarea
     id: logs
@@ -108,16 +108,16 @@ body:
         TypeError: Cannot read property 'onClick' of undefined
           at Button (button.tsx:42)
         ```
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: textarea
     id: context
     attributes:
       label: Additional Context
       description: Screenshots, links to CodeSandbox reproduction, or any other relevant context.
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/component-request.yml
+++ b/.github/ISSUE_TEMPLATE/component-request.yml
@@ -44,8 +44,8 @@ body:
         - color.neutral.gray.200 (border)
         - spacing.sm, spacing.md (padding)
         - typography.body.md (text)
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: textarea
     id: accessibility
@@ -57,8 +57,8 @@ body:
         - Keyboard navigation (arrow keys, Enter to select, Escape to close)
         - ARIA role, aria-labelledby, aria-expanded
         - Focus trap management
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: acceptance-criteria
@@ -71,8 +71,8 @@ body:
         - [ ] Passes axe-core a11y audit (WCAG 2.1 AA)
         - [ ] 80%+ test coverage (Vitest unit + Playwright CT)
         - [ ] Storybook stories for all variants/states
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: references
@@ -83,8 +83,8 @@ body:
         - Design spec: [Figma link]
         - Similar patterns: [Link to Storybook story or external reference]
         - Related issues: #XX, #YY
-      validations:
-        required: false
+    validations:
+      required: false
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/component-request.yml
+++ b/.github/ISSUE_TEMPLATE/component-request.yml
@@ -1,0 +1,100 @@
+name: 🎨 Component Request
+description: Propose a new UI component for the Isolate UI library
+title: 'feat: [component name]'
+labels: ['type: feature', 'component']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for proposing a new component! This form captures the initial context. Your request will be refined through our backlog grooming process (see [issue-refinement skill](https://github.com/SteveJRobertson/isolate-ui/blob/main/.github/skills/issue-refinement/SKILL.md)) before implementation begins.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What design problem does this component solve? Why is it needed?
+      placeholder: |
+        Example: Dropdown is a common pattern in our design system but not yet available as a reusable component. Used in [Feature X, Feature Y].
+    validations:
+      required: true
+
+  - type: textarea
+    id: component-spec
+    attributes:
+      label: Component Specification
+      description: |
+        Describe the component's purpose, states, and variants. Reference [Ark UI primitives](https://ark-ui.com) if applicable.
+      placeholder: |
+        Example:
+        - **Primitive**: Combobox (from Ark UI)
+        - **Variants**: size (sm, md, lg), disabled state
+        - **States**: open/closed, focused, hovered
+        - **Content**: label, trigger button, list items, help text
+    validations:
+      required: true
+
+  - type: textarea
+    id: design-tokens
+    attributes:
+      label: Design Tokens Required
+      description: |
+        List any design tokens from `@isolate-ui/tokens` this component depends on. Reference dot-notation paths (e.g., `color.primary.500`, `spacing.md`).
+      placeholder: |
+        - color.primary.500 (fill)
+        - color.neutral.gray.200 (border)
+        - spacing.sm, spacing.md (padding)
+        - typography.body.md (text)
+      validations:
+        required: false
+
+  - type: textarea
+    id: accessibility
+    attributes:
+      label: Accessibility Requirements
+      description: |
+        What WCAG 2.1 Level AA requirements apply? (e.g., keyboard navigation, ARIA attributes, focus management)
+      placeholder: |
+        - Keyboard navigation (arrow keys, Enter to select, Escape to close)
+        - ARIA role, aria-labelledby, aria-expanded
+        - Focus trap management
+      validations:
+        required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What does "done" look like? Be specific and measurable.
+      placeholder: |
+        - [ ] Component renders with all variants
+        - [ ] Keyboard navigation works (↑↓ to navigate, Enter to select, Escape to close)
+        - [ ] Passes axe-core a11y audit (WCAG 2.1 AA)
+        - [ ] 80%+ test coverage (Vitest unit + Playwright CT)
+        - [ ] Storybook stories for all variants/states
+      validations:
+        required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References & Context
+      description: Links to design specs, similar components, or related issues.
+      placeholder: |
+        - Design spec: [Figma link]
+        - Similar patterns: [Link to Storybook story or external reference]
+        - Related issues: #XX, #YY
+      validations:
+        required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Ensure your request is well-scoped and aligns with the project.
+      options:
+        - label: I've checked that this component doesn't already exist in the library
+          required: true
+        - label: I've reviewed [Ark UI primitives](https://ark-ui.com) to identify the appropriate base component
+          required: true
+        - label: I understand this will be refined through issue-refinement before implementation
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/SteveJRobertson/isolate-ui/discussions
+    about: Ask questions or propose ideas in Discussions before opening an issue.

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,100 @@
+name: 🔧 Maintenance
+description: Chores, refactoring, tooling improvements, and DX enhancements
+title: 'chore: [brief description]'
+labels: ['type: chore']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Maintenance work improves the codebase's quality, reliability, and developer experience without adding new features.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What type of maintenance work is this?
+      options:
+        - Select a category...
+        - Dependencies (upgrade, add, remove)
+        - Code refactoring
+        - Documentation
+        - Testing improvements
+        - Tooling/CI-CD
+        - Performance optimization
+        - Type safety improvements
+        - Other (please specify)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        What needs to be done and why? Be concise and specific.
+      placeholder: |
+        Upgrade Vitest from 3.2.4 to 4.0.0 to improve performance and get new snapshot testing features.
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: |
+        Why is this work important? (e.g., performance gains, security fix, improved DX, tech debt reduction)
+      placeholder: |
+        - Vitest 4.0 has 40% faster test runs (relevant as test suite grows)
+        - New `snapshot.inline` feature reduces file clutter
+        - Fixes 2 known bugs with coverage reporting
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope & Affected Areas
+      description: |
+        What projects or files will be affected? (e.g., all projects, specific libs, CI/CD config)
+      placeholder: |
+        - Affects all projects using Vitest (utils, react-button, ai-orchestrator)
+        - Changes: vitest.workspace.ts, individual project configs
+        - May need snapshot updates in affected projects
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What does completion look like?
+      placeholder: |
+        - [ ] Dependency upgraded to 4.0.0
+        - [ ] All tests pass locally and in CI
+        - [ ] No new warnings or deprecations
+        - [ ] Snapshots updated where necessary
+    validations:
+      required: false
+
+  - type: textarea
+    id: breaking-changes
+    attributes:
+      label: Breaking Changes or Migration Steps
+      description: |
+        Will this require changes to workflows or breaking changes? If so, document migration steps.
+      placeholder: |
+        No breaking changes for consumers. Internal steps:
+        1. Update vitest config if snapshot syntax changed
+        2. Regenerate snapshots with `pnpm vitest -- -u`
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I've confirmed this is maintenance work (not a feature or bug fix)
+          required: true
+        - label: I've checked if similar work is already in progress
+          required: false

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -14,7 +14,6 @@ body:
       label: Category
       description: What type of maintenance work is this?
       options:
-        - Select a category...
         - Dependencies (upgrade, add, remove)
         - Code refactoring
         - Documentation


### PR DESCRIPTION
## Summary

Add GitHub Issue Forms templates to standardise issue creation across the project. Templates include configuration schema, bug reports, component requests, and maintenance work.

## Changes

- Created `.github/ISSUE_TEMPLATE/config.yml` to route issue creation to available templates
- Created `.github/ISSUE_TEMPLATE/bug-report.yml` for structured bug reports
- Created `.github/ISSUE_TEMPLATE/component-request.yml` for new component requests
- Created `.github/ISSUE_TEMPLATE/maintenance.yml` for chores and refactoring work

## Copilot Review Triage

- [x] **Blocker** — No security, correctness, or unhandled rejection issues
- [x] **Major** — Form schemas are valid; no missing error handlers
- [x] **Minor** — All templates tested locally; required fields enforced correctly
- [x] **Nit** — Field naming and descriptions align with project conventions

## Deferred follow-ups

None at this time.