### PR TITLE
test(webhook-listener): cover WEBHOOK_SECRET startup guard to reach 100% coverage

### DIFF
--- a/apps/webhook-listener/src/routes/webhook.spec.ts
+++ b/apps/webhook-listener/src/routes/webhook.spec.ts
@@ -890,3 +890,54 @@ describe('webhookRoute', () => {
     });
   });
 });
+
+describe('webhookRoute — startup guard', () => {
+  let fastify;
+  let db;
+  let previousWebhookSecret: string | undefined;
+
+  beforeEach(() => {
+    fastify = Fastify();
+    db = new Database(':memory:');
+    previousWebhookSecret = process.env.WEBHOOK_SECRET;
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    if (previousWebhookSecret === undefined) {
+      delete process.env.WEBHOOK_SECRET;
+    } else {
+      process.env.WEBHOOK_SECRET = previousWebhookSecret;
+    }
+  });
+
+  it('throws when WEBHOOK_SECRET is not set', async () => {
+    delete process.env.WEBHOOK_SECRET;
+    await expect(
+      fastify.register(webhookRoute, {
+        db,
+        graph: { getState: vi.fn(), invoke: vi.fn() } as any,
+        octokit: {} as any,
+        owner: 'owner',
+        repo: 'repo',
+      }),
+    ).rejects.toThrow(
+      'WEBHOOK_SECRET must be set and at least 32 characters. Refusing to start.',
+    );
+  });
+
+  it('throws when WEBHOOK_SECRET is shorter than 32 characters', async () => {
+    process.env.WEBHOOK_SECRET = 'too-short';
+    await expect(
+      fastify.register(webhookRoute, {
+        db,
+        graph: { getState: vi.fn(), invoke: vi.fn() } as any,
+        octokit: {} as any,
+        owner: 'owner',
+        repo: 'repo',
+      }),
+    ).rejects.toThrow(
+      'WEBHOOK_SECRET must be set and at least 32 characters. Refusing to start.',
+    );
+  });
+});

--- a/apps/webhook-listener/vitest.config.mts
+++ b/apps/webhook-listener/vitest.config.mts
@@ -15,6 +15,12 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../coverage/apps/webhook-listener',
       provider: 'v8' as const,
+      thresholds: {
+        lines: 80,
+        branches: 80,
+        functions: 80,
+        statements: 80,
+      },
     },
   },
 }));


### PR DESCRIPTION
## Summary

Closes #84. Increases `webhook.ts` line coverage from 95.78% (after #83) to 100% by adding tests for the previously uncovered WEBHOOK_SECRET startup guard (lines 54-57). Also adds ≥80% coverage thresholds to `vitest.config.mts` to prevent future regressions.

## Changes

- **`apps/webhook-listener/src/routes/webhook.spec.ts`**: Add `webhookRoute — startup guard` describe block with 2 tests:
  - `throws when WEBHOOK_SECRET is not set`
  - `throws when WEBHOOK_SECRET is shorter than 32 characters`
- **`apps/webhook-listener/vitest.config.mts`**: Add `thresholds` block enforcing ≥80% on lines, branches, functions, and statements

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.

## Deferred follow-ups

None