### PR TITLE
feat(webhook-listener): implement /health endpoint and enable PM2 liveness probe

### DIFF
--- a/apps/webhook-listener/src/main.ts
+++ b/apps/webhook-listener/src/main.ts
@@ -3,6 +3,7 @@ import rawBody from 'fastify-raw-body';
 import { Octokit } from '@octokit/rest';
 import { OrchestratorGraph } from '@isolate-ui/ai-orchestrator';
 import { openDb, resolveDbPath } from './db/schema';
+import { registerHealthRoute } from './routes/health';
 import { webhookRoute } from './routes/webhook';
 import { runStartupSync } from './sync/startup';
 
@@ -43,6 +44,9 @@ async function start() {
   // Sync the graph's GitHub repo target so the human_review pause comment
   // is posted to the same repo this service is configured to watch.
   graph.setGitHubRepo(owner, repo);
+
+  // Register the health check endpoint (no dependencies; stateless)
+  await server.register(registerHealthRoute);
 
   // Register the webhook route with its dependencies
   await server.register(webhookRoute, { db, graph, octokit, owner, repo });

--- a/apps/webhook-listener/src/routes/health.spec.ts
+++ b/apps/webhook-listener/src/routes/health.spec.ts
@@ -57,4 +57,13 @@ describe('registerHealthRoute', () => {
     const body = JSON.parse(response.body);
     expect(Object.keys(body).sort()).toEqual(['status', 'timestamp']);
   });
+
+  it('returns 404 for POST /health (method not registered)', async () => {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/health',
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
 });

--- a/apps/webhook-listener/src/routes/health.spec.ts
+++ b/apps/webhook-listener/src/routes/health.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import Fastify from 'fastify';
+import { registerHealthRoute } from './health';
+
+describe('registerHealthRoute', () => {
+  let fastify;
+
+  beforeEach(async () => {
+    fastify = Fastify();
+    await fastify.register(registerHealthRoute);
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  it('returns HTTP 200 for GET /health', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/health',
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('returns JSON response with status: ok', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/health',
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('status', 'ok');
+  });
+
+  it('returns JSON response with valid ISO timestamp', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/health',
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('timestamp');
+
+    // Validate that timestamp is a valid ISO string
+    const timestamp = new Date(body.timestamp);
+    expect(timestamp instanceof Date && !isNaN(timestamp.getTime())).toBe(true);
+    expect(body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('returns response with both status and timestamp properties', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/health',
+    });
+
+    const body = JSON.parse(response.body);
+    expect(Object.keys(body).sort()).toEqual(['status', 'timestamp']);
+  });
+});

--- a/apps/webhook-listener/src/routes/health.ts
+++ b/apps/webhook-listener/src/routes/health.ts
@@ -13,13 +13,28 @@ import { FastifyInstance } from 'fastify';
  *
  * @param fastify - Fastify instance to register the route on
  */
+// Response schema locks the contract so accidental extra fields never leak.
+const healthResponseSchema = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['ok'] },
+    timestamp: { type: 'string', format: 'date-time' },
+  },
+  required: ['status', 'timestamp'],
+  additionalProperties: false,
+} as const;
+
 export async function registerHealthRoute(
   fastify: FastifyInstance,
 ): Promise<void> {
-  fastify.get('/health', async () => {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-    };
-  });
+  fastify.get(
+    '/health',
+    { schema: { response: { 200: healthResponseSchema } } },
+    async () => {
+      return {
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+      };
+    },
+  );
 }

--- a/apps/webhook-listener/src/routes/health.ts
+++ b/apps/webhook-listener/src/routes/health.ts
@@ -1,0 +1,25 @@
+import { FastifyInstance } from 'fastify';
+
+/**
+ * Register the GET /health endpoint.
+ *
+ * Returns HTTP 200 with a JSON payload containing:
+ * - status: 'ok' (constant)
+ * - timestamp: ISO 8601 timestamp of the response
+ *
+ * This endpoint is used by PM2's http_proxy liveness probe to detect
+ * zombie processes (listening but unresponsive). It has no dependencies
+ * (no DB, auth, or external calls) and is always healthy.
+ *
+ * @param fastify - Fastify instance to register the route on
+ */
+export async function registerHealthRoute(
+  fastify: FastifyInstance,
+): Promise<void> {
+  fastify.get('/health', async () => {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    };
+  });
+}

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -47,8 +47,8 @@ module.exports = {
       max_file: 14, // Keep 14 rotated log files (14 days of history)
 
       // Health check: HTTP liveness probe every 30s
-      // Uncomment once /health endpoint is implemented in webhook-listener
-      // http_proxy: 'http://localhost:8080/health',
+      // Enabled: /health endpoint is implemented and registered in webhook-listener/src/main.ts
+      http_proxy: 'http://localhost:8080/health',
 
       // Environment variables: loaded from .env.production via dotenv (above).
       // Only NODE_ENV is hardcoded here; all other vars come from .env.production.

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -47,8 +47,9 @@ module.exports = {
       max_file: 14, // Keep 14 rotated log files (14 days of history)
 
       // Health check: HTTP liveness probe every 30s
-      // Enabled: /health endpoint is implemented and registered in webhook-listener/src/main.ts
-      http_proxy: 'http://localhost:8080/health',
+      // Uses process.env.PORT so the probe stays in sync with runtime configuration.
+      // dotenv.config() above ensures PORT is populated from .env.production before this line evaluates.
+      http_proxy: `http://localhost:${process.env.PORT || 8080}/health`,
 
       // Environment variables: loaded from .env.production via dotenv (above).
       // Only NODE_ENV is hardcoded here; all other vars come from .env.production.


### PR DESCRIPTION
## Summary

Implements the `GET /health` endpoint required for PM2 liveness probing on the Mac Mini production deployment. The endpoint returns HTTP 200 with `{ status: 'ok', timestamp: ISO8601 }` and is stateless — no DB, auth, or external dependencies.

Closes #99

## Changes

- Add `apps/webhook-listener/src/routes/health.ts` — registers `GET /health` with a stateless 200 response
- Add `apps/webhook-listener/src/routes/health.spec.ts` — 4 tests covering HTTP status, `status: 'ok'`, ISO timestamp validity, and response shape
- Update `apps/webhook-listener/src/main.ts` — register health route before webhook route in startup sequence
- Update `ecosystem.config.js` — uncomment `http_proxy` PM2 liveness probe (was blocked on this endpoint)

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.

## Deferred follow-ups

None