### PR TITLE
fix(source): suppress node10 resolution deprecation

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,


### PR DESCRIPTION
## Summary

Suppresses the TypeScript `node10` module resolution deprecation warning by adding `ignoreDeprecations: "5.0"` to `tsconfig.base.json`.

Closes #77

Originally submitted as PR #96 by @leno23. Reopened from the maintainer branch to fix a commitlint scope error (`tsconfig` → `source`).

## Changes

- **tsconfig.base.json**: Add `"ignoreDeprecations": "5.0"` to compiler options

## Copilot Review Triage

- [x] **Blocker** — No security or correctness issues found
- [x] **Major** — No correctness gaps
- [x] **Minor** — `"6.0"` was considered and rejected (TS 5.9.3 throws TS5103 with that value; tracked as a future upgrade when TS 6.x is adopted)
- [x] **Nit** — None

## Deferred follow-ups

- Bump `ignoreDeprecations` to `"6.0"` once TypeScript 6.x is adopted in this project.