### PR TITLE
refactor(ai-orchestrator): accept Octokit instance in poster functions

### DIFF
--- a/libs/ai-orchestrator/src/github/poster.octokit-refactor.test.ts
+++ b/libs/ai-orchestrator/src/github/poster.octokit-refactor.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Octokit } from '@octokit/rest';
+import {
+  postRefinementLoopComment,
+  postMeshStalemateComment,
+  type RefinementCommentPayload,
+  type MeshStalematePayload,
+} from './poster';
+
+// ── Test Suite: Octokit Refactoring ───────────────────────────────────────────
+//
+// This test suite verifies that postRefinementLoopComment and postMeshStalemateComment
+// accept an Octokit instance as a parameter instead of a token string.
+// Tests will fail until the refactoring is implemented.
+
+const minimalRefinementPayload: RefinementCommentPayload = {
+  issueNumber: 19,
+  owner: 'SteveJRobertson',
+  repo: 'isolate-ui',
+  technicalSpec: [],
+  edgeCases: [],
+  signoffs: {},
+};
+
+const minimalMeshPayload: MeshStalematePayload = {
+  issueNumber: 19,
+  owner: 'SteveJRobertson',
+  repo: 'isolate-ui',
+  meshLoopCount: 3,
+  originPersona: 'dev',
+  lastMessage: 'Test message',
+  issueAuthor: 'testuser',
+  maxMeshLoops: 5,
+};
+
+// ── postRefinementLoopComment with Octokit instance ────────────────────────────
+
+describe('postRefinementLoopComment (Octokit refactor)', () => {
+  it('FAILING: accepts an Octokit instance parameter', async () => {
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: {
+        id: 12345,
+        html_url:
+          'https://github.com/SteveJRobertson/isolate-ui/issues/19#issuecomment-12345',
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
+
+    // TODO: Update function signature to accept octokit: Octokit | undefined
+    // Currently expects (payload, token) — should be (payload, octokit)
+    const result = await postRefinementLoopComment(
+      minimalRefinementPayload,
+      mockOctokit,
+    );
+
+    expect(result).toEqual({
+      commentUrl:
+        'https://github.com/SteveJRobertson/isolate-ui/issues/19#issuecomment-12345',
+      commentId: 12345,
+    });
+  });
+
+  it('FAILING: returns null when Octokit instance is not provided', async () => {
+    // TODO: Update function to check for undefined Octokit and return null
+    const result = await postRefinementLoopComment(
+      minimalRefinementPayload,
+      undefined,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('FAILING: calls issues.createComment with correct parameters', async () => {
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: {
+        id: 12345,
+        html_url:
+          'https://github.com/SteveJRobertson/isolate-ui/issues/19#issuecomment-12345',
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
+
+    const payload: RefinementCommentPayload = {
+      ...minimalRefinementPayload,
+      issueNumber: 42,
+      owner: 'TestOwner',
+      repo: 'test-repo',
+    };
+
+    await postRefinementLoopComment(payload, mockOctokit);
+
+    expect(mockCreateComment).toHaveBeenCalledWith({
+      owner: 'TestOwner',
+      repo: 'test-repo',
+      issue_number: 42,
+      body: expect.any(String),
+    });
+  });
+
+  it('FAILING: throws when Octokit call fails', async () => {
+    const mockCreateComment = vi.fn().mockRejectedValue(new Error('API Error'));
+
+    const mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      postRefinementLoopComment(minimalRefinementPayload, mockOctokit),
+    ).rejects.toThrow('API Error');
+  });
+});
+
+// ── postMeshStalemateComment with Octokit instance ────────────────────────────
+
+describe('postMeshStalemateComment (Octokit refactor)', () => {
+  it('FAILING: accepts an Octokit instance parameter', async () => {
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: {
+        id: 54321,
+        html_url:
+          'https://github.com/SteveJRobertson/isolate-ui/issues/19#issuecomment-54321',
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
+
+    // TODO: Update function signature to accept octokit: Octokit | undefined
+    // Currently expects (payload, token) — should be (payload, octokit)
+    const result = await postMeshStalemateComment(
+      minimalMeshPayload,
+      mockOctokit,
+    );
+
+    expect(result).toEqual({
+      commentUrl:
+        'https://github.com/SteveJRobertson/isolate-ui/issues/19#issuecomment-54321',
+      commentId: 54321,
+    });
+  });
+
+  it('FAILING: returns null when Octokit instance is not provided', async () => {
+    // TODO: Update function to check for undefined Octokit and return null
+    const result = await postMeshStalemateComment(
+      minimalMeshPayload,
+      undefined,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('FAILING: calls issues.createComment with correct mesh stalemate body', async () => {
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: {
+        id: 54321,
+        html_url:
+          'https://github.com/SteveJRobertson/isolate-ui/issues/19#issuecomment-54321',
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
+
+    const payload: MeshStalematePayload = {
+      ...minimalMeshPayload,
+      issueNumber: 88,
+      owner: 'OrgName',
+      repo: 'mesh-test',
+    };
+
+    await postMeshStalemateComment(payload, mockOctokit);
+
+    expect(mockCreateComment).toHaveBeenCalledWith({
+      owner: 'OrgName',
+      repo: 'mesh-test',
+      issue_number: 88,
+      body: expect.stringContaining('Ambiguity Mesh'),
+    });
+  });
+
+  it('FAILING: throws when Octokit call fails', async () => {
+    const mockCreateComment = vi
+      .fn()
+      .mockRejectedValue(new Error('Network Error'));
+
+    const mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      postMeshStalemateComment(minimalMeshPayload, mockOctokit),
+    ).rejects.toThrow('Network Error');
+  });
+});

--- a/libs/ai-orchestrator/src/github/poster.octokit-refactor.test.ts
+++ b/libs/ai-orchestrator/src/github/poster.octokit-refactor.test.ts
@@ -11,7 +11,6 @@ import {
 //
 // This test suite verifies that postRefinementLoopComment and postMeshStalemateComment
 // accept an Octokit instance as a parameter instead of a token string.
-// Tests will fail until the refactoring is implemented.
 
 const minimalRefinementPayload: RefinementCommentPayload = {
   issueNumber: 19,
@@ -36,7 +35,7 @@ const minimalMeshPayload: MeshStalematePayload = {
 // ── postRefinementLoopComment with Octokit instance ────────────────────────────
 
 describe('postRefinementLoopComment (Octokit refactor)', () => {
-  it('FAILING: accepts an Octokit instance parameter', async () => {
+  it('accepts an Octokit instance parameter', async () => {
     const mockCreateComment = vi.fn().mockResolvedValue({
       data: {
         id: 12345,
@@ -51,8 +50,6 @@ describe('postRefinementLoopComment (Octokit refactor)', () => {
       },
     } as unknown as Octokit;
 
-    // TODO: Update function signature to accept octokit: Octokit | undefined
-    // Currently expects (payload, token) — should be (payload, octokit)
     const result = await postRefinementLoopComment(
       minimalRefinementPayload,
       mockOctokit,
@@ -65,8 +62,7 @@ describe('postRefinementLoopComment (Octokit refactor)', () => {
     });
   });
 
-  it('FAILING: returns null when Octokit instance is not provided', async () => {
-    // TODO: Update function to check for undefined Octokit and return null
+  it('returns null when Octokit instance is not provided', async () => {
     const result = await postRefinementLoopComment(
       minimalRefinementPayload,
       undefined,
@@ -74,7 +70,7 @@ describe('postRefinementLoopComment (Octokit refactor)', () => {
     expect(result).toBeNull();
   });
 
-  it('FAILING: calls issues.createComment with correct parameters', async () => {
+  it('calls issues.createComment with correct parameters', async () => {
     const mockCreateComment = vi.fn().mockResolvedValue({
       data: {
         id: 12345,
@@ -106,7 +102,7 @@ describe('postRefinementLoopComment (Octokit refactor)', () => {
     });
   });
 
-  it('FAILING: throws when Octokit call fails', async () => {
+  it('throws when Octokit call fails', async () => {
     const mockCreateComment = vi.fn().mockRejectedValue(new Error('API Error'));
 
     const mockOctokit = {
@@ -124,7 +120,7 @@ describe('postRefinementLoopComment (Octokit refactor)', () => {
 // ── postMeshStalemateComment with Octokit instance ────────────────────────────
 
 describe('postMeshStalemateComment (Octokit refactor)', () => {
-  it('FAILING: accepts an Octokit instance parameter', async () => {
+  it('accepts an Octokit instance parameter', async () => {
     const mockCreateComment = vi.fn().mockResolvedValue({
       data: {
         id: 54321,
@@ -139,8 +135,6 @@ describe('postMeshStalemateComment (Octokit refactor)', () => {
       },
     } as unknown as Octokit;
 
-    // TODO: Update function signature to accept octokit: Octokit | undefined
-    // Currently expects (payload, token) — should be (payload, octokit)
     const result = await postMeshStalemateComment(
       minimalMeshPayload,
       mockOctokit,
@@ -153,8 +147,7 @@ describe('postMeshStalemateComment (Octokit refactor)', () => {
     });
   });
 
-  it('FAILING: returns null when Octokit instance is not provided', async () => {
-    // TODO: Update function to check for undefined Octokit and return null
+  it('returns null when Octokit instance is not provided', async () => {
     const result = await postMeshStalemateComment(
       minimalMeshPayload,
       undefined,
@@ -162,7 +155,7 @@ describe('postMeshStalemateComment (Octokit refactor)', () => {
     expect(result).toBeNull();
   });
 
-  it('FAILING: calls issues.createComment with correct mesh stalemate body', async () => {
+  it('calls issues.createComment with correct mesh stalemate body', async () => {
     const mockCreateComment = vi.fn().mockResolvedValue({
       data: {
         id: 54321,
@@ -194,7 +187,7 @@ describe('postMeshStalemateComment (Octokit refactor)', () => {
     });
   });
 
-  it('FAILING: throws when Octokit call fails', async () => {
+  it('throws when Octokit call fails', async () => {
     const mockCreateComment = vi
       .fn()
       .mockRejectedValue(new Error('Network Error'));

--- a/libs/ai-orchestrator/src/github/poster.test.ts
+++ b/libs/ai-orchestrator/src/github/poster.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Octokit } from '@octokit/rest';
 import {
   formatTechnicalSpecTable,
   formatEdgeCaseList,
@@ -10,18 +11,6 @@ import {
   type RefinementCommentPayload,
   type MeshStalematePayload,
 } from './poster';
-
-// ── Mock @octokit/rest at module level so it's hoisted before imports ─────────
-
-const mockCreateComment = vi.fn();
-
-vi.mock('@octokit/rest', () => ({
-  Octokit: vi.fn().mockImplementation(() => ({
-    rest: {
-      issues: { createComment: mockCreateComment },
-    },
-  })),
-}));
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -183,21 +172,22 @@ describe('buildCommentBody', () => {
 // ── postRefinementLoopComment ─────────────────────────────────────────────────
 
 describe('postRefinementLoopComment', () => {
+  let mockCreateComment: ReturnType<typeof vi.fn>;
+  let mockOctokit: Octokit;
+
   beforeEach(() => {
-    // Clear call history only — do NOT reset implementations (that removes the mock)
-    vi.clearAllMocks();
-    mockCreateComment.mockResolvedValue({
+    mockCreateComment = vi.fn().mockResolvedValue({
       data: { html_url: '', id: 0 },
     });
+    mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
   });
 
-  it('returns null when token is undefined', async () => {
+  it('returns null when octokit is undefined', async () => {
     const result = await postRefinementLoopComment(fullPayload, undefined);
-    expect(result).toBeNull();
-  });
-
-  it('returns null when token is empty string', async () => {
-    const result = await postRefinementLoopComment(fullPayload, '');
     expect(result).toBeNull();
   });
 
@@ -210,10 +200,7 @@ describe('postRefinementLoopComment', () => {
       },
     });
 
-    const result = await postRefinementLoopComment(
-      fullPayload,
-      'ghp_faketoken',
-    );
+    const result = await postRefinementLoopComment(fullPayload, mockOctokit);
 
     expect(mockCreateComment).toHaveBeenCalledWith({
       owner: 'SteveJRobertson',
@@ -307,6 +294,9 @@ describe('buildStalemateCommentBody', () => {
 // ── postMeshStalemateComment ──────────────────────────────────────────────────
 
 describe('postMeshStalemateComment', () => {
+  let mockCreateComment: ReturnType<typeof vi.fn>;
+  let mockOctokit: Octokit;
+
   const stalematePayload: MeshStalematePayload = {
     issueNumber: 20,
     owner: 'SteveJRobertson',
@@ -319,16 +309,18 @@ describe('postMeshStalemateComment', () => {
   };
 
   beforeEach(() => {
-    mockCreateComment.mockReset();
+    mockCreateComment = vi.fn().mockResolvedValue({
+      data: { html_url: '', id: 0 },
+    });
+    mockOctokit = {
+      rest: {
+        issues: { createComment: mockCreateComment },
+      },
+    } as unknown as Octokit;
   });
 
-  it('returns null when token is undefined', async () => {
+  it('returns null when octokit is undefined', async () => {
     const result = await postMeshStalemateComment(stalematePayload, undefined);
-    expect(result).toBeNull();
-  });
-
-  it('returns null when token is empty string', async () => {
-    const result = await postMeshStalemateComment(stalematePayload, '');
     expect(result).toBeNull();
   });
 
@@ -343,7 +335,7 @@ describe('postMeshStalemateComment', () => {
 
     const result = await postMeshStalemateComment(
       stalematePayload,
-      'ghp_faketoken',
+      mockOctokit,
     );
 
     expect(mockCreateComment).toHaveBeenCalledWith({

--- a/libs/ai-orchestrator/src/github/poster.ts
+++ b/libs/ai-orchestrator/src/github/poster.ts
@@ -1,4 +1,4 @@
-import { Octokit } from '@octokit/rest';
+import type { Octokit } from '@octokit/rest';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 

--- a/libs/ai-orchestrator/src/github/poster.ts
+++ b/libs/ai-orchestrator/src/github/poster.ts
@@ -169,7 +169,8 @@ export function buildCommentBody(payload: RefinementCommentPayload): string {
 /**
  * Post a refinement loop report as a GitHub issue comment.
  *
- * Requires an authenticated Octokit instance with `repo` scope.
+ * Requires an authenticated Octokit instance with permission to create issue
+ * comments (PAT `repo` scope, or GitHub App `issues: write` permission).
  * Silently skips posting and returns null when Octokit is absent.
  *
  * @param payload - Comment data
@@ -268,7 +269,8 @@ export function buildStalemateCommentBody(
 /**
  * Post a mesh stalemate notification as a GitHub issue comment.
  *
- * Requires an authenticated Octokit instance with `repo` scope.
+ * Requires an authenticated Octokit instance with permission to create issue
+ * comments (PAT `repo` scope, or GitHub App `issues: write` permission).
  * Silently skips posting and returns null when Octokit is absent.
  *
  * @param payload - Stalemate comment data

--- a/libs/ai-orchestrator/src/github/poster.ts
+++ b/libs/ai-orchestrator/src/github/poster.ts
@@ -169,20 +169,19 @@ export function buildCommentBody(payload: RefinementCommentPayload): string {
 /**
  * Post a refinement loop report as a GitHub issue comment.
  *
- * Requires a valid GITHUB_TOKEN with `repo` scope.
- * Silently skips posting and returns null when token is absent.
+ * Requires an authenticated Octokit instance with `repo` scope.
+ * Silently skips posting and returns null when Octokit is absent.
  *
  * @param payload - Comment data
- * @param token   - GitHub personal access token (GITHUB_TOKEN)
- * @returns PostCommentResult on success, null when token is absent
+ * @param octokit - Authenticated Octokit instance
+ * @returns PostCommentResult on success, null when octokit is absent
  */
 export async function postRefinementLoopComment(
   payload: RefinementCommentPayload,
-  token: string | undefined,
+  octokit: Octokit | undefined,
 ): Promise<PostCommentResult | null> {
-  if (!token) return null;
+  if (!octokit) return null;
 
-  const octokit = new Octokit({ auth: token });
   const body = buildCommentBody(payload);
 
   const response = await octokit.rest.issues.createComment({
@@ -269,20 +268,19 @@ export function buildStalemateCommentBody(
 /**
  * Post a mesh stalemate notification as a GitHub issue comment.
  *
- * Requires a valid GITHUB_TOKEN with `repo` scope.
- * Silently skips posting and returns null when token is absent.
+ * Requires an authenticated Octokit instance with `repo` scope.
+ * Silently skips posting and returns null when Octokit is absent.
  *
  * @param payload - Stalemate comment data
- * @param token   - GitHub personal access token (GITHUB_TOKEN)
- * @returns PostCommentResult on success, null when token is absent
+ * @param octokit - Authenticated Octokit instance
+ * @returns PostCommentResult on success, null when octokit is absent
  */
 export async function postMeshStalemateComment(
   payload: MeshStalematePayload,
-  token: string | undefined,
+  octokit: Octokit | undefined,
 ): Promise<PostCommentResult | null> {
-  if (!token) return null;
+  if (!octokit) return null;
 
-  const octokit = new Octokit({ auth: token });
   const body = buildStalemateCommentBody(payload);
 
   const response = await octokit.rest.issues.createComment({

--- a/libs/ai-orchestrator/src/orchestrator/langgraph.ts
+++ b/libs/ai-orchestrator/src/orchestrator/langgraph.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { Octokit } from '@octokit/rest';
 import {
   StateGraph,
   START,
@@ -390,6 +391,10 @@ export class OrchestratorGraph {
     // (which would race under concurrent run() calls).
     const localGraph = this.buildGraph();
     const githubToken = process.env['GITHUB_TOKEN'];
+    // Create Octokit instance from token if available
+    const octokit = githubToken
+      ? new Octokit({ auth: githubToken })
+      : undefined;
 
     try {
       const result = await this.invokeWithGraph(
@@ -410,7 +415,7 @@ export class OrchestratorGraph {
         await this.tryPostComment(
           result.finalState,
           threadId,
-          githubToken,
+          octokit,
           undefined,
         );
       }
@@ -432,15 +437,15 @@ export class OrchestratorGraph {
 
   /**
    * Build and post a refinement loop comment to GitHub.
-   * Silently no-ops when GITHUB_TOKEN is absent or posting fails (non-critical).
+   * Silently no-ops when Octokit is absent or posting fails (non-critical).
    */
   private async tryPostComment(
     state: AgentState,
     threadId: string,
-    token: string | undefined,
+    octokit: Octokit | undefined,
     rejectionReason: string | undefined,
   ): Promise<void> {
-    if (!token) return;
+    if (!octokit) return;
 
     // Require an explicit github_issue_id in metadata — do not derive from
     // threadId by stripping digits, as that can post to the wrong issue.
@@ -463,7 +468,7 @@ export class OrchestratorGraph {
     };
 
     try {
-      const result = await postRefinementLoopComment(payload, token);
+      const result = await postRefinementLoopComment(payload, octokit);
       if (result) {
         console.log(
           `[ai-orchestrator] GitHub comment posted: ${result.commentUrl}`,


### PR DESCRIPTION
## Summary

Refactor `postRefinementLoopComment` and `postMeshStalemateComment` in the `ai-orchestrator` library to accept an authenticated `Octokit` instance instead of a raw GitHub token string. This is a prerequisite for GitHub App authentication support (#111).

Closes #113

## Changes

- **`libs/ai-orchestrator/src/github/poster.ts`**: Changed `postRefinementLoopComment` and `postMeshStalemateComment` signatures from `(payload, token: string | undefined)` to `(payload, octokit: Octokit | undefined)`. Removed inline `new Octokit({ auth: token })` instantiation from both functions. Changed `import { Octokit }` to `import type { Octokit }` since it is now a type-only usage.
- **`libs/ai-orchestrator/src/orchestrator/langgraph.ts`**: Added `import { Octokit } from '@octokit/rest'`. Updated `run()` to create the Octokit instance from `GITHUB_TOKEN` and pass it to `tryPostComment()`. Updated `tryPostComment()` signature to accept `Octokit | undefined`.
- **`libs/ai-orchestrator/src/github/poster.test.ts`**: Removed `vi.mock('@octokit/rest')` (no longer needed). Replaced token-based test calls with mock Octokit objects. Removed `'returns null when token is empty string'` tests (empty string was a token concern; undefined Octokit covers the equivalent case).
- **`libs/ai-orchestrator/src/github/poster.octokit-refactor.test.ts`** _(new)_: TDD skeleton covering both functions — accepts Octokit instance, returns null when absent, calls `createComment` with correct params, throws on API errors.

## Copilot Review Triage

- [x] **Blocker** — No security or correctness issues found
- [x] **Major** — No reliability or correctness issues found
- [x] **Minor** — No coverage gaps found
- [x] **Nit** — 3 nit findings resolved: removed stale `FAILING:` test prefixes, removed TODO comments, changed to `import type`

## Deferred follow-ups

None.