### PR TITLE
feat(webhook-listener): add hybrid GitHub App and PAT authentication

### DIFF
--- a/apps/webhook-listener/src/auth/hybrid-auth.test.ts
+++ b/apps/webhook-listener/src/auth/hybrid-auth.test.ts
@@ -1,19 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 
-/**
- * Test skeleton for hybrid GitHub authentication (App + PAT fallback).
- * Tests will be filled in during #111 implementation.
- *
- * Requirements from Issue #111:
- * - Support authenticating via GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY_PATH + GITHUB_APP_INSTALLATION_ID
- * - Fallback to GITHUB_TOKEN (PAT) when App credentials are not available
- * - Fail gracefully when neither auth method is provided
- * - Pass the authenticated Octokit instance to command handlers
- */
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn() };
+});
 
-describe('Hybrid GitHub Authentication', () => {
+import { getAuthenticatedOctokit } from './hybrid-auth';
+
+const mockReadFileSync = vi.mocked(readFileSync);
+
+const FAKE_PEM =
+  '-----BEGIN RSA PRIVATE KEY-----\nfakekey\n-----END RSA PRIVATE KEY-----';
+
+describe('getAuthenticatedOctokit', () => {
   beforeEach(() => {
-    vi.clearAllEnv();
+    delete process.env['GITHUB_APP_ID'];
+    delete process.env['GITHUB_APP_PRIVATE_KEY_PATH'];
+    delete process.env['GITHUB_APP_INSTALLATION_ID'];
+    delete process.env['GITHUB_TOKEN'];
+    mockReadFileSync.mockReset();
   });
 
   afterEach(() => {
@@ -23,117 +29,166 @@ describe('Hybrid GitHub Authentication', () => {
   // ── GitHub App Authentication ─────────────────────────────────────────────
 
   describe('GitHub App Authentication', () => {
-    it('FAILING: creates Octokit instance with App credentials', async () => {
-      // TODO: Set up environment variables
-      process.env.GITHUB_APP_ID = '12345';
-      process.env.GITHUB_APP_PRIVATE_KEY_PATH = '/path/to/key.pem';
-      process.env.GITHUB_APP_INSTALLATION_ID = '67890';
+    it('returns an Octokit instance when App credentials are provided', async () => {
+      process.env['GITHUB_APP_ID'] = '12345';
+      process.env['GITHUB_APP_PRIVATE_KEY_PATH'] = '/path/to/key.pem';
+      process.env['GITHUB_APP_INSTALLATION_ID'] = '67890';
+      mockReadFileSync.mockReturnValue(FAKE_PEM);
 
-      // TODO: Create and call getAuthenticatedOctokit()
-      // const octokit = await getAuthenticatedOctokit();
+      const octokit = await getAuthenticatedOctokit();
 
-      // Should use @octokit/auth-app to create an authenticated client
-      // expect(octokit).toBeDefined();
-      // expect(octokit.rest).toBeDefined();
+      expect(octokit).toBeDefined();
+      expect(octokit.rest).toBeDefined();
     });
 
-    it('FAILING: reads private key from file path', async () => {
-      // TODO: Mock filesystem
-      // TODO: Verify that the key file is read correctly from GITHUB_APP_PRIVATE_KEY_PATH
-      // Should not embed the key in environment; should read from filesystem
+    it('reads the private key from GITHUB_APP_PRIVATE_KEY_PATH', async () => {
+      process.env['GITHUB_APP_ID'] = '12345';
+      process.env['GITHUB_APP_PRIVATE_KEY_PATH'] = '/path/to/key.pem';
+      process.env['GITHUB_APP_INSTALLATION_ID'] = '67890';
+      mockReadFileSync.mockReturnValue(FAKE_PEM);
+
+      await getAuthenticatedOctokit();
+
+      expect(mockReadFileSync).toHaveBeenCalledWith('/path/to/key.pem', 'utf8');
     });
 
-    it('FAILING: fails gracefully when private key file is missing', async () => {
-      // TODO: Set invalid path for GITHUB_APP_PRIVATE_KEY_PATH
-      // Should throw with clear error message
-      // expect(getAuthenticatedOctokit()).rejects.toThrow(/key file|not found/i);
+    it('throws when the private key file cannot be read', async () => {
+      process.env['GITHUB_APP_ID'] = '12345';
+      process.env['GITHUB_APP_PRIVATE_KEY_PATH'] = '/nonexistent/key.pem';
+      process.env['GITHUB_APP_INSTALLATION_ID'] = '67890';
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+
+      await expect(getAuthenticatedOctokit()).rejects.toThrow(
+        /Failed to read/i,
+      );
     });
 
-    it('FAILING: fails gracefully when required App env var is missing', async () => {
-      // TODO: Test each missing App environment variable:
-      // - GITHUB_APP_ID missing
-      // - GITHUB_APP_PRIVATE_KEY_PATH missing
-      // - GITHUB_APP_INSTALLATION_ID missing
-      // Should throw or return null with clear error
+    it('throws when not all App env vars are set and no PAT is available', async () => {
+      process.env['GITHUB_APP_ID'] = '12345';
+      // GITHUB_APP_PRIVATE_KEY_PATH and GITHUB_APP_INSTALLATION_ID are absent
+
+      await expect(getAuthenticatedOctokit()).rejects.toThrow(
+        /GITHUB_TOKEN|App credentials/i,
+      );
     });
   });
 
   // ── PAT (Personal Access Token) Fallback ───────────────────────────────────
 
   describe('PAT Fallback Authentication', () => {
-    it('FAILING: creates Octokit instance with GITHUB_TOKEN', async () => {
-      // TODO: Set only GITHUB_TOKEN (no App credentials)
-      process.env.GITHUB_TOKEN = 'ghp_test1234567890abcdef';
+    it('returns an Octokit instance when GITHUB_TOKEN is set', async () => {
+      process.env['GITHUB_TOKEN'] = 'ghp_test1234567890abcdef';
 
-      // TODO: Call getAuthenticatedOctokit()
-      // Should create Octokit with token auth
+      const octokit = await getAuthenticatedOctokit();
 
-      // const octokit = await getAuthenticatedOctokit();
-      // expect(octokit).toBeDefined();
+      expect(octokit).toBeDefined();
+      expect(octokit.rest).toBeDefined();
     });
 
-    it('FAILING: prefers App auth when both App and PAT are available', async () => {
-      // TODO: Set both GITHUB_APP_* and GITHUB_TOKEN
-      process.env.GITHUB_APP_ID = '12345';
-      process.env.GITHUB_APP_PRIVATE_KEY_PATH = '/path/to/key.pem';
-      process.env.GITHUB_APP_INSTALLATION_ID = '67890';
-      process.env.GITHUB_TOKEN = 'ghp_test1234567890abcdef';
+    it('prefers App auth over PAT when both are available', async () => {
+      process.env['GITHUB_APP_ID'] = '12345';
+      process.env['GITHUB_APP_PRIVATE_KEY_PATH'] = '/path/to/key.pem';
+      process.env['GITHUB_APP_INSTALLATION_ID'] = '67890';
+      process.env['GITHUB_TOKEN'] = 'ghp_test1234567890abcdef';
+      mockReadFileSync.mockReturnValue(FAKE_PEM);
 
-      // TODO: Should use App auth, not PAT
-      // const octokit = await getAuthenticatedOctokit();
-      // Verify that it's using App auth (possibly by checking auth type)
+      await getAuthenticatedOctokit();
+
+      // App auth was selected — readFileSync was called for the private key
+      expect(mockReadFileSync).toHaveBeenCalledWith('/path/to/key.pem', 'utf8');
     });
   });
 
   // ── Fallback and Error Handling ────────────────────────────────────────────
 
   describe('Authentication Fallback and Error Handling', () => {
-    it('FAILING: fails when neither App nor PAT credentials are provided', async () => {
-      // TODO: Clear all auth environment variables
-      // No GITHUB_TOKEN, no GITHUB_APP_*
-      // Should throw with clear error message telling user to set one method
-      // expect(getAuthenticatedOctokit()).rejects.toThrow(/GitHub Token|App credentials/i);
+    it('throws when neither App nor PAT credentials are provided', async () => {
+      await expect(getAuthenticatedOctokit()).rejects.toThrow(
+        /GITHUB_TOKEN|App credentials/i,
+      );
     });
 
-    it('FAILING: logs which auth method is being used (for debugging)', async () => {
-      // TODO: Mock console.log or a logger
-      // TODO: Verify that startup logs indicate which auth method was selected
-      // Should log: "Using GitHub App authentication" or "Using PAT (GitHub Token) authentication"
-    });
-  });
+    it('logs the PAT auth method when GITHUB_TOKEN is used', async () => {
+      const consoleSpy = vi.spyOn(console, 'log');
+      process.env['GITHUB_TOKEN'] = 'ghp_test1234567890abcdef';
 
-  // ── Integration with Command Handlers ──────────────────────────────────────
+      await getAuthenticatedOctokit();
 
-  describe('Integration with Command Handlers', () => {
-    it('FAILING: passes authenticated Octokit instance to webhook route', async () => {
-      // TODO: Create a test that verifies the Octokit instance is passed through
-      // to the webhook route handler
-      // Command handlers (approve, fix, query) should receive the Octokit instance
-      // and use it to make API calls, not create their own from a token
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/PAT|GitHub Token/i),
+      );
     });
 
-    it('FAILING: all command handlers use the passed Octokit instance', async () => {
-      // TODO: Verify that approve, fix, and query handlers don't create their own Octokit
-      // They should accept it as a parameter and use it
-      // This ensures that the auth method (App or PAT) is centralized and consistent
+    it('logs the GitHub App auth method when App credentials are used', async () => {
+      const consoleSpy = vi.spyOn(console, 'log');
+      process.env['GITHUB_APP_ID'] = '12345';
+      process.env['GITHUB_APP_PRIVATE_KEY_PATH'] = '/path/to/key.pem';
+      process.env['GITHUB_APP_INSTALLATION_ID'] = '67890';
+      mockReadFileSync.mockReturnValue(FAKE_PEM);
+
+      await getAuthenticatedOctokit();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/GitHub App/i),
+      );
     });
   });
 
   // ── Environment Variable Validation ────────────────────────────────────────
 
   describe('Environment Variable Validation', () => {
-    it('FAILING: startup fails with clear error when GITHUB_APP_ID is invalid', async () => {
-      // TODO: Test non-numeric GITHUB_APP_ID
-      process.env.GITHUB_APP_ID = 'not-a-number';
+    it('throws when GITHUB_APP_ID is not a valid integer', async () => {
+      process.env['GITHUB_APP_ID'] = 'not-a-number';
+      process.env['GITHUB_APP_PRIVATE_KEY_PATH'] = '/path/to/key.pem';
+      process.env['GITHUB_APP_INSTALLATION_ID'] = '67890';
 
-      // Should reject or log a clear error
+      await expect(getAuthenticatedOctokit()).rejects.toThrow(/GITHUB_APP_ID/i);
     });
 
-    it('FAILING: startup fails with clear error when GITHUB_APP_INSTALLATION_ID is invalid', async () => {
-      // TODO: Test non-numeric GITHUB_APP_INSTALLATION_ID
-      process.env.GITHUB_APP_INSTALLATION_ID = 'not-a-number';
+    it('throws when GITHUB_APP_INSTALLATION_ID is not a valid integer', async () => {
+      process.env['GITHUB_APP_ID'] = '12345';
+      process.env['GITHUB_APP_PRIVATE_KEY_PATH'] = '/path/to/key.pem';
+      process.env['GITHUB_APP_INSTALLATION_ID'] = 'not-a-number';
 
-      // Should reject or log a clear error
+      await expect(getAuthenticatedOctokit()).rejects.toThrow(
+        /GITHUB_APP_INSTALLATION_ID/i,
+      );
+    });
+  });
+
+  // ── Integration with Command Handlers ──────────────────────────────────────
+
+  describe('Integration with Command Handlers', () => {
+    it('CommandContext includes octokit as a required field', async () => {
+      const { makeCommandContext } = await import('../__tests__/test-helpers');
+      const mockOctokit = {
+        rest: { issues: { createComment: vi.fn() } },
+      } as any;
+      const ctx = makeCommandContext({ octokit: mockOctokit });
+
+      expect(ctx.octokit).toBe(mockOctokit);
+    });
+
+    it('postErrorReply uses ctx.octokit to post the comment', async () => {
+      const { postErrorReply } = await import('../commands/context');
+      const { makeCommandContext } = await import('../__tests__/test-helpers');
+      const createComment = vi.fn().mockResolvedValue({});
+      const mockOctokit = { rest: { issues: { createComment } } } as any;
+      const ctx = makeCommandContext({
+        octokit: mockOctokit,
+        issueNumber: 42,
+        username: 'test-user',
+        owner: 'owner',
+        repo: 'repo',
+      });
+
+      await postErrorReply(ctx, 'test error');
+
+      expect(createComment).toHaveBeenCalledWith(
+        expect.objectContaining({ issue_number: 42 }),
+      );
     });
   });
 });

--- a/apps/webhook-listener/src/auth/hybrid-auth.test.ts
+++ b/apps/webhook-listener/src/auth/hybrid-auth.test.ts
@@ -6,24 +6,47 @@ vi.mock('node:fs', async (importOriginal) => {
   return { ...actual, readFileSync: vi.fn() };
 });
 
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn().mockImplementation(() => ({ rest: {} })),
+}));
+
 import { getAuthenticatedOctokit } from './hybrid-auth';
+import { Octokit } from '@octokit/rest';
 
 const mockReadFileSync = vi.mocked(readFileSync);
+const MockOctokit = vi.mocked(Octokit);
 
 const FAKE_PEM =
   '-----BEGIN RSA PRIVATE KEY-----\nfakekey\n-----END RSA PRIVATE KEY-----';
 
 describe('getAuthenticatedOctokit', () => {
+  let savedEnv: Record<string, string | undefined>;
+
   beforeEach(() => {
+    savedEnv = {
+      GITHUB_APP_ID: process.env['GITHUB_APP_ID'],
+      GITHUB_APP_PRIVATE_KEY_PATH: process.env['GITHUB_APP_PRIVATE_KEY_PATH'],
+      GITHUB_APP_INSTALLATION_ID: process.env['GITHUB_APP_INSTALLATION_ID'],
+      GITHUB_TOKEN: process.env['GITHUB_TOKEN'],
+    };
     delete process.env['GITHUB_APP_ID'];
     delete process.env['GITHUB_APP_PRIVATE_KEY_PATH'];
     delete process.env['GITHUB_APP_INSTALLATION_ID'];
     delete process.env['GITHUB_TOKEN'];
     mockReadFileSync.mockReset();
+    MockOctokit.mockClear();
+    MockOctokit.mockImplementation(() => ({ rest: {} }));
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    vi.restoreAllMocks();
   });
 
   // ── GitHub App Authentication ─────────────────────────────────────────────
@@ -65,12 +88,12 @@ describe('getAuthenticatedOctokit', () => {
       );
     });
 
-    it('throws when not all App env vars are set and no PAT is available', async () => {
+    it('throws with incomplete App credentials message when partial App vars are set', async () => {
       process.env['GITHUB_APP_ID'] = '12345';
       // GITHUB_APP_PRIVATE_KEY_PATH and GITHUB_APP_INSTALLATION_ID are absent
 
       await expect(getAuthenticatedOctokit()).rejects.toThrow(
-        /GITHUB_TOKEN|App credentials/i,
+        /Incomplete GitHub App credentials/i,
       );
     });
   });

--- a/apps/webhook-listener/src/auth/hybrid-auth.test.ts
+++ b/apps/webhook-listener/src/auth/hybrid-auth.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Test skeleton for hybrid GitHub authentication (App + PAT fallback).
+ * Tests will be filled in during #111 implementation.
+ *
+ * Requirements from Issue #111:
+ * - Support authenticating via GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY_PATH + GITHUB_APP_INSTALLATION_ID
+ * - Fallback to GITHUB_TOKEN (PAT) when App credentials are not available
+ * - Fail gracefully when neither auth method is provided
+ * - Pass the authenticated Octokit instance to command handlers
+ */
+
+describe('Hybrid GitHub Authentication', () => {
+  beforeEach(() => {
+    vi.clearAllEnv();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── GitHub App Authentication ─────────────────────────────────────────────
+
+  describe('GitHub App Authentication', () => {
+    it('FAILING: creates Octokit instance with App credentials', async () => {
+      // TODO: Set up environment variables
+      process.env.GITHUB_APP_ID = '12345';
+      process.env.GITHUB_APP_PRIVATE_KEY_PATH = '/path/to/key.pem';
+      process.env.GITHUB_APP_INSTALLATION_ID = '67890';
+
+      // TODO: Create and call getAuthenticatedOctokit()
+      // const octokit = await getAuthenticatedOctokit();
+
+      // Should use @octokit/auth-app to create an authenticated client
+      // expect(octokit).toBeDefined();
+      // expect(octokit.rest).toBeDefined();
+    });
+
+    it('FAILING: reads private key from file path', async () => {
+      // TODO: Mock filesystem
+      // TODO: Verify that the key file is read correctly from GITHUB_APP_PRIVATE_KEY_PATH
+      // Should not embed the key in environment; should read from filesystem
+    });
+
+    it('FAILING: fails gracefully when private key file is missing', async () => {
+      // TODO: Set invalid path for GITHUB_APP_PRIVATE_KEY_PATH
+      // Should throw with clear error message
+      // expect(getAuthenticatedOctokit()).rejects.toThrow(/key file|not found/i);
+    });
+
+    it('FAILING: fails gracefully when required App env var is missing', async () => {
+      // TODO: Test each missing App environment variable:
+      // - GITHUB_APP_ID missing
+      // - GITHUB_APP_PRIVATE_KEY_PATH missing
+      // - GITHUB_APP_INSTALLATION_ID missing
+      // Should throw or return null with clear error
+    });
+  });
+
+  // ── PAT (Personal Access Token) Fallback ───────────────────────────────────
+
+  describe('PAT Fallback Authentication', () => {
+    it('FAILING: creates Octokit instance with GITHUB_TOKEN', async () => {
+      // TODO: Set only GITHUB_TOKEN (no App credentials)
+      process.env.GITHUB_TOKEN = 'ghp_test1234567890abcdef';
+
+      // TODO: Call getAuthenticatedOctokit()
+      // Should create Octokit with token auth
+
+      // const octokit = await getAuthenticatedOctokit();
+      // expect(octokit).toBeDefined();
+    });
+
+    it('FAILING: prefers App auth when both App and PAT are available', async () => {
+      // TODO: Set both GITHUB_APP_* and GITHUB_TOKEN
+      process.env.GITHUB_APP_ID = '12345';
+      process.env.GITHUB_APP_PRIVATE_KEY_PATH = '/path/to/key.pem';
+      process.env.GITHUB_APP_INSTALLATION_ID = '67890';
+      process.env.GITHUB_TOKEN = 'ghp_test1234567890abcdef';
+
+      // TODO: Should use App auth, not PAT
+      // const octokit = await getAuthenticatedOctokit();
+      // Verify that it's using App auth (possibly by checking auth type)
+    });
+  });
+
+  // ── Fallback and Error Handling ────────────────────────────────────────────
+
+  describe('Authentication Fallback and Error Handling', () => {
+    it('FAILING: fails when neither App nor PAT credentials are provided', async () => {
+      // TODO: Clear all auth environment variables
+      // No GITHUB_TOKEN, no GITHUB_APP_*
+      // Should throw with clear error message telling user to set one method
+      // expect(getAuthenticatedOctokit()).rejects.toThrow(/GitHub Token|App credentials/i);
+    });
+
+    it('FAILING: logs which auth method is being used (for debugging)', async () => {
+      // TODO: Mock console.log or a logger
+      // TODO: Verify that startup logs indicate which auth method was selected
+      // Should log: "Using GitHub App authentication" or "Using PAT (GitHub Token) authentication"
+    });
+  });
+
+  // ── Integration with Command Handlers ──────────────────────────────────────
+
+  describe('Integration with Command Handlers', () => {
+    it('FAILING: passes authenticated Octokit instance to webhook route', async () => {
+      // TODO: Create a test that verifies the Octokit instance is passed through
+      // to the webhook route handler
+      // Command handlers (approve, fix, query) should receive the Octokit instance
+      // and use it to make API calls, not create their own from a token
+    });
+
+    it('FAILING: all command handlers use the passed Octokit instance', async () => {
+      // TODO: Verify that approve, fix, and query handlers don't create their own Octokit
+      // They should accept it as a parameter and use it
+      // This ensures that the auth method (App or PAT) is centralized and consistent
+    });
+  });
+
+  // ── Environment Variable Validation ────────────────────────────────────────
+
+  describe('Environment Variable Validation', () => {
+    it('FAILING: startup fails with clear error when GITHUB_APP_ID is invalid', async () => {
+      // TODO: Test non-numeric GITHUB_APP_ID
+      process.env.GITHUB_APP_ID = 'not-a-number';
+
+      // Should reject or log a clear error
+    });
+
+    it('FAILING: startup fails with clear error when GITHUB_APP_INSTALLATION_ID is invalid', async () => {
+      // TODO: Test non-numeric GITHUB_APP_INSTALLATION_ID
+      process.env.GITHUB_APP_INSTALLATION_ID = 'not-a-number';
+
+      // Should reject or log a clear error
+    });
+  });
+});

--- a/apps/webhook-listener/src/auth/hybrid-auth.test.ts
+++ b/apps/webhook-listener/src/auth/hybrid-auth.test.ts
@@ -7,7 +7,11 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 vi.mock('@octokit/rest', () => ({
-  Octokit: vi.fn().mockImplementation(() => ({ rest: {} })),
+  Octokit: vi
+    .fn()
+    .mockImplementation(
+      () => ({ rest: {} }) as unknown as import('@octokit/rest').Octokit,
+    ),
 }));
 
 import { getAuthenticatedOctokit } from './hybrid-auth';
@@ -35,7 +39,7 @@ describe('getAuthenticatedOctokit', () => {
     delete process.env['GITHUB_TOKEN'];
     mockReadFileSync.mockReset();
     MockOctokit.mockClear();
-    MockOctokit.mockImplementation(() => ({ rest: {} }));
+    MockOctokit.mockImplementation(() => ({ rest: {} }) as unknown as Octokit);
   });
 
   afterEach(() => {

--- a/apps/webhook-listener/src/auth/hybrid-auth.ts
+++ b/apps/webhook-listener/src/auth/hybrid-auth.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { Octokit } from '@octokit/rest';
+import { createAppAuth } from '@octokit/auth-app';
+
+/**
+ * Creates an authenticated Octokit instance using the best available credentials.
+ *
+ * Priority:
+ * 1. GitHub App authentication — requires GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY_PATH,
+ *    and GITHUB_APP_INSTALLATION_ID to all be set.
+ * 2. PAT authentication — requires GITHUB_TOKEN to be set.
+ *
+ * Throws if neither set of credentials is available, or if App credentials are
+ * present but invalid (non-integer IDs, unreadable key file).
+ */
+export async function getAuthenticatedOctokit(): Promise<Octokit> {
+  const appId = process.env['GITHUB_APP_ID'];
+  const privateKeyPath = process.env['GITHUB_APP_PRIVATE_KEY_PATH'];
+  const installationId = process.env['GITHUB_APP_INSTALLATION_ID'];
+
+  if (appId && privateKeyPath && installationId) {
+    const appIdNum = Number(appId);
+    if (isNaN(appIdNum) || !Number.isInteger(appIdNum) || appIdNum <= 0) {
+      throw new Error(
+        `[hybrid-auth] GITHUB_APP_ID must be a positive integer, got: "${appId}"`,
+      );
+    }
+
+    const installationIdNum = Number(installationId);
+    if (
+      isNaN(installationIdNum) ||
+      !Number.isInteger(installationIdNum) ||
+      installationIdNum <= 0
+    ) {
+      throw new Error(
+        `[hybrid-auth] GITHUB_APP_INSTALLATION_ID must be a positive integer, got: "${installationId}"`,
+      );
+    }
+
+    let privateKey: string;
+    try {
+      privateKey = readFileSync(privateKeyPath, 'utf8') as string;
+    } catch (err) {
+      throw new Error(
+        `[hybrid-auth] Failed to read GitHub App private key file at "${privateKeyPath}": ${String(err)}`,
+      );
+    }
+
+    console.log('[hybrid-auth] Using GitHub App authentication');
+    return new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        appId: appIdNum,
+        privateKey,
+        installationId: installationIdNum,
+      },
+    });
+  }
+
+  const token = process.env['GITHUB_TOKEN'];
+  if (token) {
+    console.log('[hybrid-auth] Using PAT (GitHub Token) authentication');
+    return new Octokit({ auth: token });
+  }
+
+  throw new Error(
+    '[hybrid-auth] No GitHub authentication credentials found. ' +
+      'Set GITHUB_TOKEN for PAT authentication, or set GITHUB_APP_ID, ' +
+      'GITHUB_APP_PRIVATE_KEY_PATH, and GITHUB_APP_INSTALLATION_ID for GitHub App authentication.',
+  );
+}

--- a/apps/webhook-listener/src/auth/hybrid-auth.ts
+++ b/apps/webhook-listener/src/auth/hybrid-auth.ts
@@ -18,6 +18,22 @@ export async function getAuthenticatedOctokit(): Promise<Octokit> {
   const privateKeyPath = process.env['GITHUB_APP_PRIVATE_KEY_PATH'];
   const installationId = process.env['GITHUB_APP_INSTALLATION_ID'];
 
+  // Partial App credentials — some but not all vars set means misconfiguration, not a fallback
+  const appVarsDefined = [appId, privateKeyPath, installationId].filter(
+    Boolean,
+  ).length;
+  if (appVarsDefined > 0 && appVarsDefined < 3) {
+    const missing = [
+      !appId && 'GITHUB_APP_ID',
+      !privateKeyPath && 'GITHUB_APP_PRIVATE_KEY_PATH',
+      !installationId && 'GITHUB_APP_INSTALLATION_ID',
+    ].filter(Boolean);
+    throw new Error(
+      `[hybrid-auth] Incomplete GitHub App credentials. Missing: ${missing.join(', ')}. ` +
+        `Set all three to use App authentication, or unset all to fall back to GITHUB_TOKEN.`,
+    );
+  }
+
   if (appId && privateKeyPath && installationId) {
     const appIdNum = Number(appId);
     if (isNaN(appIdNum) || !Number.isInteger(appIdNum) || appIdNum <= 0) {
@@ -39,7 +55,7 @@ export async function getAuthenticatedOctokit(): Promise<Octokit> {
 
     let privateKey: string;
     try {
-      privateKey = readFileSync(privateKeyPath, 'utf8') as string;
+      privateKey = readFileSync(privateKeyPath, 'utf8');
     } catch (err) {
       throw new Error(
         `[hybrid-auth] Failed to read GitHub App private key file at "${privateKeyPath}": ${String(err)}`,

--- a/apps/webhook-listener/src/main.ts
+++ b/apps/webhook-listener/src/main.ts
@@ -1,26 +1,16 @@
 import Fastify from 'fastify';
 import rawBody from 'fastify-raw-body';
-import { Octokit } from '@octokit/rest';
 import { OrchestratorGraph } from '@isolate-ui/ai-orchestrator';
 import { openDb, resolveDbPath } from './db/schema';
 import { registerHealthRoute } from './routes/health';
 import { webhookRoute } from './routes/webhook';
 import { runStartupSync } from './sync/startup';
+import { getAuthenticatedOctokit } from './auth/hybrid-auth';
 
 const host = process.env.HOST ?? '0.0.0.0'; // bind to all interfaces so GitHub/Tailscale can reach the service
 const port = process.env.PORT ? Number(process.env.PORT) : 8080;
 const owner = process.env.GITHUB_OWNER ?? 'SteveJRobertson';
 const repo = process.env.GITHUB_REPO ?? 'isolate-ui';
-
-// GITHUB_TOKEN is required: startup sync and all error replies depend on it.
-// Fail immediately with a clear message so misconfiguration is obvious.
-if (!process.env['GITHUB_TOKEN']) {
-  console.error(
-    '[webhook-listener] GITHUB_TOKEN is not set. ' +
-      'Set it to a PAT with `repo` scope before starting the service.',
-  );
-  process.exit(1);
-}
 
 async function start() {
   const server = Fastify({ logger: true });
@@ -38,7 +28,7 @@ async function start() {
   // same SQLite file (important when DATABASE_PATH env var is set).
   const dbPath = resolveDbPath();
   const db = openDb(dbPath);
-  const octokit = new Octokit({ auth: process.env['GITHUB_TOKEN'] });
+  const octokit = await getAuthenticatedOctokit();
   const graph = new OrchestratorGraph(dbPath);
 
   // Sync the graph's GitHub repo target so the human_review pause comment

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@ark-ui/react": "^5.34.1",
+    "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
     "better-sqlite3": "^12.9.0",
     "fastify": "~5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ark-ui/react':
         specifier: ^5.34.1
         version: 5.34.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@octokit/auth-app':
+        specifier: ^8.2.0
+        version: 8.2.0
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -2243,6 +2246,22 @@ packages:
   '@nx/workspace@22.5.4':
     resolution: {integrity: sha512-TZeuCDy+VN/5zqMYxHw15HKe2Ppcb9WBOebz4bmXE206c8Aop3S9QeLfys00Uobt9ZaYh9QUeN0iFsZm7TNv0w==}
 
+  '@octokit/auth-app@8.2.0':
+    resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.3':
+    resolution: {integrity: sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.3':
+    resolution: {integrity: sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.2':
+    resolution: {integrity: sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==}
+    engines: {node: '>= 20'}
+
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
@@ -2257,6 +2276,14 @@ packages:
 
   '@octokit/graphql@9.0.3':
     resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.2':
+    resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
     engines: {node: '>= 20'}
 
   '@octokit/openapi-types@27.0.0':
@@ -8450,6 +8477,9 @@ packages:
     resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
     engines: {node: '>= 0.8.0'}
 
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
@@ -11638,6 +11668,40 @@ snapshots:
       - '@swc/core'
       - debug
 
+  '@octokit/auth-app@8.2.0':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.3':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.3':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.2':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -11660,6 +11724,15 @@ snapshots:
       '@octokit/request': 10.0.8
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.2':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
 
   '@octokit/openapi-types@27.0.0': {}
 
@@ -19091,6 +19164,8 @@ snapshots:
   union@0.5.0:
     dependencies:
       qs: 6.15.0
+
+  universal-github-app-jwt@2.2.2: {}
 
   universal-user-agent@7.0.3: {}
 


### PR DESCRIPTION
## Summary

Implements hybrid GitHub authentication for the webhook-listener service, supporting both GitHub App credentials and PAT (Personal Access Token) as a fallback. Centralises Octokit instantiation into a single `getAuthenticatedOctokit()` function.

Closes #111

## Changes

- **`apps/webhook-listener/src/auth/hybrid-auth.ts`** (new): `getAuthenticatedOctokit()` — creates an Octokit instance using GitHub App auth (`GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY_PATH` + `GITHUB_APP_INSTALLATION_ID`) when all three env vars are set, otherwise falls back to PAT (`GITHUB_TOKEN`). Throws with a clear message when neither is configured. Validates numeric env vars and wraps file-read errors.
- **`apps/webhook-listener/src/main.ts`**: Replaced hard `GITHUB_TOKEN` guard and `new Octokit({ auth: ... })` with `await getAuthenticatedOctokit()`. Error propagates to the existing `start().catch()` handler.
- **`apps/webhook-listener/src/auth/hybrid-auth.test.ts`**: Replaced skeleton with 13 tests covering App credentials, PAT fallback, auth preference, missing credentials, key file errors, and env var validation.
- **`package.json` / `pnpm-lock.yaml`**: Added `@octokit/auth-app@8.2.0` to `dependencies`.

## Copilot Review Triage

- [x] Blocker — none
- [x] Major — none
- [x] Minor — none
- [x] Nit — two `as any` casts in test file (mock Octokit objects, not public API boundary; consistent with all existing test files in the project)

## Deferred follow-ups

None.