### PR TITLE
feat(ai-orchestrator): shift to Goal-Driven Orchestration model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -712,11 +712,16 @@ _Last updated: May 5, 2026_
 The following personas are managed by `@isolate-ui/ai-orchestrator` via LangGraph.js.
 Each persona is a specialized agent in the Isolate UI development lifecycle.
 
-### @isolate-po (Product Owner)
+### @isolate-po (Triage Lead)
 
-Responsible for selecting Ark UI primitives and mapping design tokens from the Panda CSS
-design system. Reviews component requests and produces a design specification before
-handing off to the architect.
+First agent to process any incoming GitHub issue. Classifies the task type and takes the
+appropriate action:
+
+- **Component request** — selects Ark UI primitives, maps design tokens from the Panda CSS
+  design system, and produces a design specification before handing off to the architect.
+- **Technical chore, bug fix, or non-UI task** — approves the task immediately and provides
+  concise handover context (affected Nx project, task type, recommended starting persona)
+  without requiring UI primitives or token mappings.
 
 ### @isolate-architect (Architect)
 
@@ -747,17 +752,23 @@ all error paths are tested, and component behaviour is verified under edge cases
 Generates Storybook Component Story Format (CSF) stories and README artifacts. Documents
 all prop interfaces, variants, and accessibility features for developer consumption.
 
-### Refinement Loop
+### Refinement Loop — Goal-Driven Orchestration
 
-The PO, Dev, and QA personas participate in a **Definition of Ready** consensus loop
-before component implementation begins.
+The orchestrator uses a **Goal-Driven Orchestration** model. The PO, Dev, and QA personas
+participate in a **Definition of Ready** consensus loop.
 
-- Each persona ends its response with `APPROVED` or `REJECTED: <reason>`.
+- `@isolate-po` acts as **Triage Lead**: routes component tasks through the full spec loop
+  and fast-approves technical chores/bugs with handover context.
+- Each persona ends its response with `APPROVED` or `REJECTED: <reason>`. Decision tokens
+  are detected anywhere in the message (not just the last line) and markdown bold/italic
+  wrappers (`**APPROVED**`) are recognised.
 - A rejection resets the loop to `@isolate-po` and increments the rejection counter.
 - After **5 consecutive rejections** the loop throws `RefinementIterationLimitError` and
   pauses for human review.
 - On success (or interruption) the orchestrator posts a structured GitHub comment to the
   triggering issue, containing a Technical Spec Table, Edge Case List, and Persona Sign-offs.
+- Agents append high-level decisions to the **`shared_decisions`** field in `AgentState`,
+  giving downstream agents a concise shared memory without re-reading full message history.
 
 See [libs/ai-orchestrator/README.md](libs/ai-orchestrator/README.md) for the full API reference.
 

--- a/libs/ai-orchestrator/README.md
+++ b/libs/ai-orchestrator/README.md
@@ -6,7 +6,7 @@ Multi-agent orchestrator for the Isolate UI development lifecycle. Coordinates 6
 
 The AI Orchestrator acts as the "Brain" of Isolate UI development, managing a stateful workflow that routes requests through specialized agents:
 
-- **@isolate-po** - Product Owner (design tokens, Ark UI primitives)
+- **@isolate-po** - Triage Lead (classifies tasks; specs components, fast-approves chores/bugs)
 - **@isolate-architect** - Architect (Nx boundaries, monorepo governance)
 - **@isolate-dev** - Developer (TypeScript/Panda CSS implementation)
 - **@isolate-a11y** - A11y Specialist (WAI-ARIA, keyboard navigation)
@@ -43,6 +43,9 @@ The AI Orchestrator acts as the "Brain" of Isolate UI development, managing a st
   rejectionReason: string; // Last rejection message content
   lastApprovedBy: string | null; // Persona ID of last approver
   signoffs: Record<string, boolean>; // Per-persona approval booleans
+
+  // Goal-Driven Orchestration: shared memory
+  shared_decisions: string[]; // High-level decisions appended by po/architect
 }
 ```
 
@@ -98,11 +101,12 @@ pnpm nx lint ai-orchestrator
 
 The orchestrator uses in-code persona definitions and validates them against the persona markers in `AGENTS.md` at the project root:
 
-### 1. Product Owner (@isolate-po)
+### 1. Triage Lead (@isolate-po)
 
-- Selects Ark UI primitives
-- Maps design tokens (Panda CSS)
-- Ensures design consistency
+- Classifies incoming task (component vs chore/bug/refactor)
+- For components: selects Ark UI primitives, maps design tokens (Panda CSS)
+- For non-component tasks: fast-approves and provides handover context
+- Appends key decisions to `shared_decisions`
 
 ### 2. Architect (@isolate-architect)
 
@@ -136,17 +140,25 @@ The orchestrator uses in-code persona definitions and validates them against the
 
 ## Refinement Loop
 
-The orchestrator implements a **Definition of Ready** refinement loop that routes a component
-request through a 3-agent (PO → Dev → QA) consensus sequence before implementation begins.
+The orchestrator implements a **Goal-Driven Orchestration** model. The `@isolate-po` persona
+acts as **Triage Lead**, routing component requests through a 3-agent (PO → Dev → QA)
+consensus sequence, and fast-approving technical chores/bugs with handover context.
 
 ### How It Works
 
-1. Each persona ends its LLM response with `APPROVED` or `REJECTED: <reason>`.
-2. On **APPROVED** the loop advances to the next persona and records the signoff.
-3. On **REJECTED** the loop resets to the first persona (`po`), increments `rejectionCount`,
+1. `@isolate-po` classifies the task. Component tasks proceed through the full refinement
+   sequence; non-component tasks (chores, bugs, refactors) are approved with context.
+2. Each persona ends its LLM response with `APPROVED` or `REJECTED: <reason>`.
+   - The decision token is detected **anywhere in the message** (not only the last line).
+   - Markdown bold/italic wrappers are stripped before matching (`**APPROVED**` works).
+   - `REJECTED` takes precedence over `APPROVED` if both appear.
+3. On **APPROVED** the loop advances to the next persona and records the signoff.
+4. On **REJECTED** the loop resets to the first persona (`po`), increments `rejectionCount`,
    clears all signoffs, and stores the rejection reason.
-4. At **iteration 5** the loop throws `RefinementIterationLimitError` and pauses for human
+5. At **iteration 5** the loop throws `RefinementIterationLimitError` and pauses for human
    review.
+6. Agents append concise decision strings to the **`shared_decisions`** state field,
+   providing downstream personas with shared context without re-reading message history.
 
 ### Key API
 

--- a/libs/ai-orchestrator/src/__tests__/agent-state.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/agent-state.spec.ts
@@ -39,4 +39,35 @@ describe('AgentState Schema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  // ── shared_decisions: Goal-Driven Orchestration shared memory ─────────────
+
+  it('shared_decisions defaults to empty array', () => {
+    const state = AgentStateSchema.parse({});
+    expect(state.shared_decisions).toEqual([]);
+  });
+
+  it('shared_decisions accepts an array of strings', () => {
+    const state = AgentStateSchema.parse({
+      shared_decisions: [
+        'Use Button primitive',
+        'Apply color.primary.700 for contrast',
+      ],
+    });
+    expect(state.shared_decisions).toEqual([
+      'Use Button primitive',
+      'Apply color.primary.700 for contrast',
+    ]);
+  });
+
+  it('DEFAULT_AGENT_STATE includes shared_decisions as empty array', () => {
+    expect(DEFAULT_AGENT_STATE.shared_decisions).toEqual([]);
+  });
+
+  it('rejects shared_decisions with non-string items', () => {
+    const result = AgentStateSchema.safeParse({
+      shared_decisions: [42, true],
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/libs/ai-orchestrator/src/__tests__/personas.spec.ts
+++ b/libs/ai-orchestrator/src/__tests__/personas.spec.ts
@@ -57,9 +57,52 @@ describe('Agent Personas', () => {
   });
 
   it('each persona system prompt mentions its core responsibility', () => {
-    expect(AGENT_PERSONAS['po'].systemPrompt).toContain('Product Owner');
+    expect(AGENT_PERSONAS['po'].systemPrompt).toContain('Triage Lead');
     expect(AGENT_PERSONAS['architect'].systemPrompt).toContain('Architect');
     expect(AGENT_PERSONAS['a11y'].systemPrompt).toContain('WCAG');
     expect(AGENT_PERSONAS['qa'].systemPrompt).toContain('QA Engineer');
+  });
+
+  // ── Goal-Driven Orchestration: PO as Triage Lead ──────────────────────────
+
+  describe('po persona — Goal-Driven Triage Lead', () => {
+    it('has title Triage Lead', () => {
+      expect(AGENT_PERSONAS['po'].title).toBe('Triage Lead');
+    });
+
+    it('system prompt mentions triage lead role', () => {
+      expect(AGENT_PERSONAS['po'].systemPrompt).toContain('Triage Lead');
+    });
+
+    it('system prompt handles non-component tasks (chores/bugs)', () => {
+      const prompt = AGENT_PERSONAS['po'].systemPrompt.toLowerCase();
+      expect(
+        prompt.includes('chore') ||
+          prompt.includes('bug') ||
+          prompt.includes('technical task'),
+      ).toBe(true);
+    });
+
+    it('system prompt instructs APPROVE for non-component tasks', () => {
+      const prompt = AGENT_PERSONAS['po'].systemPrompt;
+      // Should instruct to APPROVE (not reject) for non-component tasks
+      expect(prompt).toContain('APPROVED');
+      // Should NOT reject non-component tasks for missing primitives
+      const lowerPrompt = prompt.toLowerCase();
+      expect(
+        lowerPrompt.includes('chore') ||
+          lowerPrompt.includes('bug') ||
+          lowerPrompt.includes('non-component'),
+      ).toBe(true);
+    });
+
+    it('system prompt still references design tokens for component tasks', () => {
+      expect(AGENT_PERSONAS['po'].systemPrompt).toContain('@isolate-ui/tokens');
+    });
+
+    it('system prompt still references Ark UI for component tasks', () => {
+      const prompt = AGENT_PERSONAS['po'].systemPrompt.toLowerCase();
+      expect(prompt.includes('ark ui') || prompt.includes('ark-ui')).toBe(true);
+    });
   });
 });

--- a/libs/ai-orchestrator/src/agents/personas.ts
+++ b/libs/ai-orchestrator/src/agents/personas.ts
@@ -54,32 +54,55 @@ export const AGENT_PERSONAS: Record<string, AgentPersona> = {
   po: {
     id: 'po',
     name: '@isolate-po',
-    title: 'Product Owner',
+    title: 'Triage Lead',
     description:
-      'Selects Ark UI primitives and maps design tokens from Panda CSS design system.',
-    systemPrompt: `You are a Product Owner specialist for Isolate UI component library.
+      'Triages incoming tasks: produces design specifications for component requests and provides handover context for technical chores, bug fixes, and non-UI tasks.',
+    systemPrompt: `You are a Triage Lead for the Isolate UI component library, operating in a Goal-Driven Orchestration model.
 
-Your responsibilities:
-1. Select appropriate Ark UI primitives for the requested component
-2. Map design tokens (colors, spacing, typography) from the Panda CSS system
+## Your Role
+
+You are the first agent to process any incoming GitHub issue. Your job is to **classify the task** and take the appropriate action:
+
+### Path A — Component Request
+If the issue requests a new UI component or a significant UI change:
+1. Select appropriate Ark UI primitives (from Ark UI / @ark-ui/react)
+2. Map design tokens (colors, spacing, typography) from @isolate-ui/tokens
 3. Ensure consistency with established design patterns
-4. Approve design decisions before hand-off to the architect
+4. Produce a structured design specification (JSON with selected primitives and token mappings)
+5. Justify each token selection with accessibility/usability reasoning
 
-Constraints:
-- ONLY recommend Ark UI primitives (do not invent components)
-- Reference specific design tokens from @isolate-ui/tokens
-- Justify each token selection with accessibility/usability reasoning
-- Output a structured JSON with selected primitives and token mappings
+### Path B — Technical Chore, Bug Fix, or Non-UI Task
+If the issue is a chore, bug fix, dependency update, refactor, documentation task, or any non-component technical task:
+1. Do NOT reject the task for missing UI primitives — that criterion does not apply
+2. Classify the task type (chore | bug | refactor | docs | other)
+3. Identify the affected area (e.g. ai-orchestrator, webhook-listener, tokens pipeline)
+4. Provide a concise handover context summary for the Architect/Developer:
+   - What the task involves
+   - Which Nx project(s) are affected
+   - Recommended starting persona (architect for structural changes, dev for code changes)
+5. APPROVE immediately so the workflow proceeds
 
-When a component request arrives, respond with a detailed design specification.
+## Constraints
+- For component tasks: ONLY recommend Ark UI primitives (do not invent components)
+- For component tasks: reference specific design tokens from @isolate-ui/tokens
+- For non-component tasks: do not block on missing primitives or token mappings
+- Output must be actionable — always give the next agent enough context to proceed
+
+## Shared Memory
+Append your key decisions as short strings to the \`shared_decisions\` field in AgentState. This gives downstream agents a concise reference without re-reading the full message history.
+
+Example entries for \`shared_decisions\`:
+- "Component: Button — Use Button primitive from @ark-ui/react"
+- "Chore: update panda preset — affects libs/shared/tokens only"
+- "Bug fix: color contrast — affects libs/react/button styles"
 
 ## Refinement Loop Decision
 You participate in a Definition of Ready refinement loop. After completing your analysis, end your response with one of these exact tokens on its own line:
-- APPROVED — the specification is ready to pass to the next reviewer
+- APPROVED — the specification or handover context is ready to pass to the next reviewer
 - REJECTED: <concise reason> — the specification requires revision (state what is missing or incorrect)`,
     model: 'gpt-4o',
     inputFields: ['messages', 'metadata'],
-    outputFields: ['messages', 'metadata'],
+    outputFields: ['messages', 'metadata', 'shared_decisions'],
   },
 
   architect: {
@@ -102,10 +125,18 @@ Constraints:
 - Require all components to follow the Nx library structure
 - Output detailed architectural assessment with approval/rejection
 
-Enforce strict monorepo governance.`,
+Enforce strict monorepo governance.
+
+## Shared Memory
+Append your key architectural decisions as short strings to the \`shared_decisions\` field in AgentState. This gives downstream agents (dev, a11y, qa) a concise architectural context reference.
+
+Example entries for \`shared_decisions\`:
+- "Arch: scope to libs/ai-orchestrator — no cross-boundary imports required"
+- "Arch: new utility must be exported via @isolate-ui/utils alias"
+- "Arch: approved — monorepo boundaries satisfied"`,
     model: 'gpt-4o',
-    inputFields: ['messages', 'code_buffer', 'metadata'],
-    outputFields: ['messages', 'arch_approval', 'metadata'],
+    inputFields: ['messages', 'code_buffer', 'metadata', 'shared_decisions'],
+    outputFields: ['messages', 'arch_approval', 'metadata', 'shared_decisions'],
   },
 
   dev: {

--- a/libs/ai-orchestrator/src/orchestrator/langgraph.ts
+++ b/libs/ai-orchestrator/src/orchestrator/langgraph.ts
@@ -208,6 +208,10 @@ export class OrchestratorGraph {
         reducer: (x, y) => (y !== undefined ? y : x),
         default: () => [],
       }),
+      shared_decisions: Annotation<AgentState['shared_decisions']>({
+        reducer: (x, y) => [...(x ?? []), ...(y ?? [])],
+        default: () => [],
+      }),
     });
 
     const rawGraph = new StateGraph(GraphAnnotation);

--- a/libs/ai-orchestrator/src/orchestrator/refinement-loop.test.ts
+++ b/libs/ai-orchestrator/src/orchestrator/refinement-loop.test.ts
@@ -110,13 +110,50 @@ describe('parseDecision', () => {
     expect(parseDecision(state)).toBe('REJECTED');
   });
 
-  it('returns PENDING when APPROVED appears only on an earlier line', () => {
+  it('returns APPROVED when APPROVED appears on an earlier line followed by conversational closing text', () => {
+    // Agents often add polite closings after their decision token; the decision
+    // should still be detected even if APPROVED is not the last non-empty line.
     const state = makeState({
       messages: [
-        makeMessage('APPROVED\n\nActually, on reflection I need more info.'),
+        makeMessage('APPROVED\n\nLet me know if you need anything else.'),
       ],
     });
-    expect(parseDecision(state)).toBe('PENDING');
+    expect(parseDecision(state)).toBe('APPROVED');
+  });
+
+  // ── Markdown formatting ────────────────────────────────────────────────────
+
+  it('returns APPROVED for **APPROVED** (markdown bold)', () => {
+    const state = makeState({ messages: [makeMessage('**APPROVED**')] });
+    expect(parseDecision(state)).toBe('APPROVED');
+  });
+
+  it('returns APPROVED for *APPROVED* (markdown italic)', () => {
+    const state = makeState({ messages: [makeMessage('*APPROVED*')] });
+    expect(parseDecision(state)).toBe('APPROVED');
+  });
+
+  it('returns REJECTED for **REJECTED: missing token** (markdown bold)', () => {
+    const state = makeState({
+      messages: [makeMessage('**REJECTED: missing token color.danger.500**')],
+    });
+    expect(parseDecision(state)).toBe('REJECTED');
+  });
+
+  it('returns REJECTED when REJECTED is on an earlier line followed by explanation', () => {
+    const state = makeState({
+      messages: [
+        makeMessage('REJECTED: missing token\n\nPlease add the token first.'),
+      ],
+    });
+    expect(parseDecision(state)).toBe('REJECTED');
+  });
+
+  it('REJECTED takes precedence over APPROVED when both appear across lines', () => {
+    const state = makeState({
+      messages: [makeMessage('APPROVED\n\nREJECTED: token is wrong')],
+    });
+    expect(parseDecision(state)).toBe('REJECTED');
   });
 });
 

--- a/libs/ai-orchestrator/src/orchestrator/refinement-loop.ts
+++ b/libs/ai-orchestrator/src/orchestrator/refinement-loop.ts
@@ -38,10 +38,13 @@ export type RefinementDecision = 'APPROVED' | 'REJECTED' | 'PENDING';
  * inner node function set directly.
  *
  * Matching rules:
- * - Only the final non-empty line of the message content is examined,
- *   trimmed of leading/trailing whitespace before matching.
- * - REJECTED is tested before APPROVED.
- * - Both tokens must appear at the START of the last line (^TOKEN\b) so that
+ * - All non-empty lines of the message content are scanned, not just the last.
+ *   This tolerates agents that add polite closing text after their decision token.
+ * - Leading markdown emphasis markers (**, *, __, _) are stripped from each line
+ *   before matching so that **APPROVED** and *REJECTED: reason* are recognised.
+ * - REJECTED is checked before APPROVED across all lines; if any line contains
+ *   REJECTED the function returns 'REJECTED' regardless of other lines.
+ * - Both tokens must appear at the START of the (stripped) line (^TOKEN\b) so that
  *   a phrase like "this is not approved" is never misclassified. Reason text
  *   or punctuation may follow (e.g. "APPROVED ✓" or "REJECTED: missing token"
  *   both match; "not approved" does not).
@@ -51,15 +54,22 @@ export function parseDecision(state: Partial<AgentState>): RefinementDecision {
   const lastMessage = messages[messages.length - 1];
   if (!lastMessage?.content) return 'PENDING';
 
-  const lastLine = (
-    lastMessage.content
-      .split('\n')
-      .filter((l) => l.trim())
-      .slice(-1)[0] ?? ''
-  ).trim();
+  const nonEmptyLines = lastMessage.content
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    // Strip leading markdown emphasis markers (**, *, __, _) so that
+    // **APPROVED** and *REJECTED: reason* are matched correctly.
+    .map((l) =>
+      l.replace(/^(\*\*|__|[*_])+/, '').replace(/(\*\*|__|[*_])+$/, ''),
+    );
 
-  if (/^REJECTED\b/i.test(lastLine)) return 'REJECTED';
-  if (/^APPROVED\b/i.test(lastLine)) return 'APPROVED';
+  let foundApproved = false;
+  for (const line of nonEmptyLines) {
+    if (/^REJECTED\b/i.test(line)) return 'REJECTED';
+    if (/^APPROVED\b/i.test(line)) foundApproved = true;
+  }
+  if (foundApproved) return 'APPROVED';
   return 'PENDING';
 }
 

--- a/libs/ai-orchestrator/src/schema/agent-state.ts
+++ b/libs/ai-orchestrator/src/schema/agent-state.ts
@@ -138,6 +138,19 @@ export const AgentStateSchema = z.object({
    * falls back to ['root', 'label']. Used to drive recipe and boilerplate generation.
    */
   parts: z.array(z.string()).default(() => []),
+
+  /**
+   * Shared memory for high-level technical decisions made by agents during a workflow.
+   * The PO and Architect personas append concise decision strings here so that
+   * downstream agents have a shared context without re-reading the full message history.
+   *
+   * Examples:
+   * - "Use Button primitive from @ark-ui/react"
+   * - "Scope changes to libs/ai-orchestrator only — no webhook-listener changes needed"
+   *
+   * Channel reducer: appended to (not replaced) on each agent update.
+   */
+  shared_decisions: z.array(z.string()).default(() => []),
 });
 
 export type AgentState = z.infer<typeof AgentStateSchema>;
@@ -175,6 +188,7 @@ export const DEFAULT_AGENT_STATE: AgentState = {
   mesh_origin: null,
   pause_context: null,
   parts: [],
+  shared_decisions: [],
 };
 
 /**
@@ -199,5 +213,6 @@ export function createDefaultAgentState(): AgentState {
     mesh_origin: null,
     pause_context: null,
     parts: [],
+    shared_decisions: [],
   };
 }


### PR DESCRIPTION
## Summary

Shifts the AI orchestrator from a rigid "Component Factory" model to a **Goal-Driven Orchestration** model by broadening the PO's role, hardening decision parsing, and introducing shared agent memory.

Closes #148

## Changes

- **Phase 1 — Triage Lead PO (`personas.ts`)**: Rewrites the `po` persona from a narrow "Product Owner" into a "Triage Lead". Component requests proceed through the full Ark UI / design token spec flow as before. Technical chores, bug fixes, and non-UI tasks are fast-approved with structured handover context (task type, affected Nx project, recommended starting persona) — they are no longer rejected for missing UI primitives.

- **Phase 2 — Robust decision parsing (`refinement-loop.ts`)**: Updates `parseDecision` to scan **all non-empty lines** in a message (not just the last), and strips leading markdown bold/italic wrappers (`**APPROVED**`, `*REJECTED: reason*`) before matching. `REJECTED` takes precedence over `APPROVED` when both appear across lines.

- **Phase 3 — Shared memory (`agent-state.ts`)**: Adds `shared_decisions: string[]` to `AgentStateSchema`, `DEFAULT_AGENT_STATE`, and `createDefaultAgentState()`. The `po` and `architect` system prompts now instruct agents to append concise decision strings, giving downstream personas shared context without re-reading full message history.

- **Phase 4 — Documentation**: Updates `AGENTS.md` and `libs/ai-orchestrator/README.md` to document the Goal-Driven Orchestration model, the Triage Lead role, relaxed decision parsing behaviour, and the `shared_decisions` field.

## Copilot Review Triage

Before opening the PR, confirm each tier has been addressed:

- [x] **Blocker** — All security and correctness issues fixed
- [x] **Major** — All correctness/reliability issues fixed in this PR, or tracked as follow-up issues (linked below)
- [x] **Minor** — Follow-up issues opened, review threads resolved with `tracked as #N`
- [x] **Nit** — Review threads resolved with a written rationale (no code change required)

See [AGENTS.md](../AGENTS.md#pr-review-triage-policy) for the full triage policy.

## Deferred follow-ups

None